### PR TITLE
Implement IgnoreAllCalls call modifier

### DIFF
--- a/devdoc/umock_c_lib_requirements_with_ids.md
+++ b/devdoc/umock_c_lib_requirements_with_ids.md
@@ -749,9 +749,9 @@ X**SRS_UMOCK_C_LIB_01_129: [** ValidateArgumentBuffer shall only be available fo
 
 ###IgnoreAllCalls(void)
 
-**SRS_UMOCK_C_LIB_01_101: [**The IgnoreAllCalls call modifier shall record that all calls matching the expected call shall be ignored. If no matching call occurs no missing call shall be reported.**]**
-**SRS_UMOCK_C_LIB_01_102: [**If multiple matching actual calls occur no unexpected calls shall be reported.**]**
-**SRS_UMOCK_C_LIB_01_103: [**The call matching shall be done taking into account arguments and call modifiers referring to arguments.**]**
+XX**SRS_UMOCK_C_LIB_01_101: [**The IgnoreAllCalls call modifier shall record that all calls matching the expected call shall be ignored.**]** XX**SRS_UMOCK_C_LIB_01_208: [** If no matching call occurs no missing call shall be reported. **]**
+XX**SRS_UMOCK_C_LIB_01_102: [**If multiple matching actual calls occur no unexpected calls shall be reported.**]**
+XX**SRS_UMOCK_C_LIB_01_103: [**The call matching shall be done taking into account arguments and call modifiers referring to arguments.**]**
 
 ###CaptureReturn(return_type* captured_return_value)
 

--- a/devdoc/umockcall_requirements.md
+++ b/devdoc/umockcall_requirements.md
@@ -21,6 +21,8 @@ umockcall is a module that encapsulates a umock call.
     extern UMOCKCALL_HANDLE umockcall_clone(UMOCKCALL_HANDLE umockcall);
     extern int umockcall_set_fail_call(UMOCKCALL_HANDLE umockcall, int fail_call);
     extern int umockcall_get_fail_call(UMOCKCALL_HANDLE umockcall);
+    extern int umockcall_set_ignore_all_calls(UMOCKCALL_HANDLE umockcall, int ignore_all_calls);
+    extern int umockcall_get_ignore_all_calls(UMOCKCALL_HANDLE umockcall);
 ```
 
 ##umockcall_create
@@ -113,4 +115,22 @@ extern int umockcall_get_fail_call(UMOCKCALL_HANDLE umockcall);
 
 **SRS_UMOCKCALL_01_041: [** umockcall_get_fail_call shall retrieve the fail_call value, associated with the umockcall call instance. **]**
 **SRS_UMOCKCALL_01_042: [** If umockcall is NULL, umockcall_get_fail_call shall return -1. **]**
+ 
+##umockcall_set_fail_call
+
+```c
+extern int umockcall_set_ignore_all_calls(UMOCKCALL_HANDLE umockcall, int ignore_all_calls);
+```
+
+**SRS_UMOCKCALL_01_045: [** umockcall_set_ignore_all_calls shall store the ignore_all_calls value, associating it with the umockcall call instance. **]**
+**SRS_UMOCKCALL_01_046: [** On success umockcall_set_ignore_all_calls shall return 0. **]**
+**SRS_UMOCKCALL_01_047: [** If umockcall is NULL, umockcall_set_ignore_all_calls shall return a non-zero value. **]**
+**SRS_UMOCKCALL_01_048: [** If a value different than 0 and 1 is passed as ignore_all_calls, umockcall_set_ignore_all_calls shall return a non-zero value. **]**
+
+```c
+extern int umockcall_get_ignore_all_calls(UMOCKCALL_HANDLE umockcall);
+```
+
+**SRS_UMOCKCALL_01_049: [** umockcall_get_ignore_all_calls shall retrieve the fail_call value, associated with the umockcall call instance. **]**
+**SRS_UMOCKCALL_01_050: [** If umockcall is NULL, umockcall_get_ignore_all_calls shall return -1. **]**
  

--- a/devdoc/umockcallrecorder_requirements.md
+++ b/devdoc/umockcallrecorder_requirements.md
@@ -75,6 +75,8 @@ extern int umockcallrecorder_add_actual_call(UMOCKCALLRECORDER_HANDLE umock_call
 **SRS_UMOCKCALLRECORDER_01_019: [** If any of the arguments is NULL, umockcallrecorder_add_actual_call shall fail and return a non-zero value. **]**
 **SRS_UMOCKCALLRECORDER_01_020: [** If allocating memory for the actual calls fails, umockcallrecorder_add_actual_call shall fail and return a non-zero value. **]**
 **SRS_UMOCKCALLRECORDER_01_021: [** If umockcall_are_equal fails, umockcallrecorder_add_actual_call shall fail and return a non-zero value. **]**
+**SRS_UMOCKCALLRECORDER_01_057: [** If any expected call has `ignore_all_calls` set and the actual call is equal to it when comparing the 2 calls, then the call shall be considered matched and not added to the actual calls list. **]**
+**SRS_UMOCKCALLRECORDER_01_058: [** If getting `ignore_all_calls` by calling `umockcall_get_ignore_all_calls` fails, `umockcallrecorder_add_actual_call` shall fail and return a non-zero value. **]**
 
 ##umockcallrecorder_get_actual_calls
 
@@ -99,6 +101,9 @@ extern const char* umockcallrecorder_get_expected_calls(UMOCKCALLRECORDER_HANDLE
 **SRS_UMOCKCALLRECORDER_01_029: [** If the umock_call_recorder is NULL, umockcallrecorder_get_expected_calls shall fail and return NULL. **]** 
 **SRS_UMOCKCALLRECORDER_01_030: [** If umockcall_stringify fails, umockcallrecorder_get_expected_calls shall fail and return NULL. **]**
 **SRS_UMOCKCALLRECORDER_01_031: [** If allocating memory for the resulting string fails, umockcallrecorder_get_expected_calls shall fail and return NULL. **]**
+**SRS_UMOCKCALLRECORDER_01_054: [** Calls that have the `ignore_all_calls` property set shall not be reported in the expected call list. **]**
+**SRS_UMOCKCALLRECORDER_01_055: [** Getting the `ignore_all_calls` property shall be done by calling `umockcall_get_ignore_all_calls`. **]**
+**SRS_UMOCKCALLRECORDER_01_056: [** If `umockcall_get_ignore_all_calls` returns a negative value then `umockcallrecorder_get_expected_calls` shall fail and return NULL. **]**
 
 ##umockcallrecorder_get_last_expected_call
 

--- a/inc/umock_c_internal.h
+++ b/inc/umock_c_internal.h
@@ -572,10 +572,35 @@ typedef int(*TRACK_DESTROY_FUNC_TYPE)(PAIRED_HANDLES* paired_handles, const void
         return mock_call_modifier; \
     } \
 
+/* Codes_SRS_UMOCK_C_LIB_01_101: [The IgnoreAllCalls call modifier shall record that all calls matching the expected call shall be ignored. If no matching call occurs no missing call shall be reported.]*/
+/* Codes_SRS_UMOCK_C_LIB_01_208: [ If no matching call occurs no missing call shall be reported. ]*/
 #define IMPLEMENT_IGNORE_ALL_CALLS_FUNCTION(return_type, name, ...) \
     static C2(mock_call_modifier_,name) C2(ignore_all_calls_func_,name)(void) \
     { \
         DECLARE_MOCK_CALL_MODIFIER(name) \
+        UMOCKCALL_HANDLE last_expected_call = umock_c_get_last_expected_call(); \
+        if (last_expected_call == NULL) \
+        { \
+            UMOCK_LOG("Cannot get last expected call."); \
+            umock_c_indicate_error(UMOCK_C_ERROR); \
+        } \
+        else \
+        { \
+            C2(mock_call_, name)* mock_call_data = (C2(mock_call_, name)*)umockcall_get_call_data(last_expected_call); \
+            if (mock_call_data == NULL) \
+            { \
+                UMOCK_LOG("ValidateArgumentBuffer called without having an expected call."); \
+                umock_c_indicate_error(UMOCK_C_ERROR); \
+            } \
+            else \
+            { \
+                if (umockcall_set_ignore_all_calls(last_expected_call, 1) != 0) \
+                { \
+                    UMOCK_LOG("Cannot set the ignore_all_calls value on the last expected call."); \
+                    umock_c_indicate_error(UMOCK_C_ERROR); \
+                } \
+            } \
+        } \
         return mock_call_modifier; \
     } \
 

--- a/inc/umockcall.h
+++ b/inc/umockcall.h
@@ -25,6 +25,8 @@ extern "C" {
     extern UMOCKCALL_HANDLE umockcall_clone(UMOCKCALL_HANDLE umockcall);
     extern int umockcall_set_fail_call(UMOCKCALL_HANDLE umockcall, int fail_call);
     extern int umockcall_get_fail_call(UMOCKCALL_HANDLE umockcall);
+    extern int umockcall_set_ignore_all_calls(UMOCKCALL_HANDLE umockcall, int ignore_all_calls);
+    extern int umockcall_get_ignore_all_calls(UMOCKCALL_HANDLE umockcall);
 
 #ifdef __cplusplus
 }

--- a/src/umockcall.c
+++ b/src/umockcall.c
@@ -16,6 +16,7 @@ typedef struct UMOCKCALL_TAG
     UMOCKCALL_DATA_STRINGIFY_FUNC umockcall_data_stringify;
     UMOCKCALL_DATA_ARE_EQUAL_FUNC umockcall_data_are_equal;
     unsigned int fail_call : 1;
+    unsigned int ignore_all_calls : 1;
 } UMOCKCALL;
 
 UMOCKCALL_HANDLE umockcall_create(const char* function_name, void* umockcall_data, UMOCKCALL_DATA_COPY_FUNC umockcall_data_copy, UMOCKCALL_DATA_FREE_FUNC umockcall_data_free, UMOCKCALL_DATA_STRINGIFY_FUNC umockcall_data_stringify, UMOCKCALL_DATA_ARE_EQUAL_FUNC umockcall_data_are_equal)
@@ -59,6 +60,7 @@ UMOCKCALL_HANDLE umockcall_create(const char* function_name, void* umockcall_dat
                 result->umockcall_data_stringify = umockcall_data_stringify;
                 result->umockcall_data_are_equal = umockcall_data_are_equal;
                 result->fail_call = 0;
+                result->ignore_all_calls = 0;
             }
         }
     }
@@ -250,6 +252,7 @@ UMOCKCALL_HANDLE umockcall_clone(UMOCKCALL_HANDLE umockcall)
                     result->umockcall_data_copy = umockcall->umockcall_data_copy;
                     result->umockcall_data_free = umockcall->umockcall_data_free;
                     result->umockcall_data_stringify = umockcall->umockcall_data_stringify;
+                    result->ignore_all_calls = umockcall->ignore_all_calls;
                     result->fail_call = umockcall->fail_call;
                 }
             }
@@ -274,7 +277,7 @@ int umockcall_set_fail_call(UMOCKCALL_HANDLE umockcall, int fail_call)
         switch (fail_call)
         {
         default:
-            UMOCK_LOG("umockcall_set_fail_call: Invalid fail_cal value: %d.", fail_call);
+            UMOCK_LOG("umockcall_set_fail_call: Invalid fail_call value: %d.", fail_call);
             result = __LINE__;
             break;
         case 0:
@@ -302,12 +305,69 @@ int umockcall_get_fail_call(UMOCKCALL_HANDLE umockcall)
     if (umockcall == NULL)
     {
         /* Codes_SRS_UMOCKCALL_01_042: [ If umockcall is NULL, umockcall_get_fail_call shall return -1. ]*/
+        UMOCK_LOG("NULL umokcall argument.");
         result = -1;
     }
     else
     {
         /* Codes_SRS_UMOCKCALL_01_041: [ umockcall_get_fail_call shall retrieve the fail_call value, associated with the umockcall call instance. ]*/
         result = umockcall->fail_call ? 1 : 0;
+    }
+
+    return result;
+}
+
+int umockcall_set_ignore_all_calls(UMOCKCALL_HANDLE umockcall, int ignore_all_calls)
+{
+    int result;
+
+    if (umockcall == NULL)
+    {
+        /* Codes_SRS_UMOCKCALL_01_047: [ If umockcall is NULL, umockcall_set_ignore_all_calls shall return a non-zero value. ]*/
+        UMOCK_LOG("umockcall_set_fail_call: NULL umockcall.");
+        result = __LINE__;
+    }
+    else
+    {
+        switch (ignore_all_calls)
+        {
+        default:
+            /* Codes_SRS_UMOCKCALL_01_048: [ If a value different than 0 and 1 is passed as ignore_all_calls, umockcall_set_ignore_all_calls shall return a non-zero value. ]*/
+            UMOCK_LOG("umockcall_set_fail_call: Invalid ignore_all_calls value: %d.", ignore_all_calls);
+            result = __LINE__;
+            break;
+        case 0:
+            /* Codes_SRS_UMOCKCALL_01_045: [ umockcall_set_ignore_all_calls shall store the ignore_all_calls value, associating it with the umockcall call instance. ]*/
+            umockcall->ignore_all_calls = 0;
+            /* Codes_SRS_UMOCKCALL_01_046: [ On success umockcall_set_ignore_all_calls shall return 0. ]*/
+            result = 0;
+            break;
+        case 1:
+            /* Codes_SRS_UMOCKCALL_01_045: [ umockcall_set_ignore_all_calls shall store the ignore_all_calls value, associating it with the umockcall call instance. ]*/
+            umockcall->ignore_all_calls = 1;
+            /* Codes_SRS_UMOCKCALL_01_046: [ On success umockcall_set_ignore_all_calls shall return 0. ]*/
+            result = 0;
+            break;
+        }
+    }
+
+    return result;
+}
+
+int umockcall_get_ignore_all_calls(UMOCKCALL_HANDLE umockcall)
+{
+    int result;
+
+    if (umockcall == NULL)
+    {
+        /* Codes_SRS_UMOCKCALL_01_050: [ If umockcall is NULL, umockcall_get_ignore_all_calls shall return -1. ]*/
+        UMOCK_LOG("NULL umokcall argument.");
+        result = -1;
+    }
+    else
+    {
+        /* Codes_SRS_UMOCKCALL_01_049: [ umockcall_get_ignore_all_calls shall retrieve the ignore_all_calls value, associated with the umockcall call instance. ]*/
+        result = umockcall->ignore_all_calls ? 1 : 0;
     }
 
     return result;

--- a/tests/umock_c_int/umock_c_int.c
+++ b/tests/umock_c_int/umock_c_int.c
@@ -2721,4 +2721,108 @@ TEST_FUNCTION(auto_ignore_when_first_arg_is_a_struct_succeeds_for_2nd_arg)
     ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_actual_calls());
 }
 
+/* Tests_SRS_UMOCK_C_LIB_01_101: [The IgnoreAllCalls call modifier shall record that all calls matching the expected call shall be ignored. ]*/
+/* Tests_SRS_UMOCK_C_LIB_01_208: [ If no matching call occurs no missing call shall be reported. ]*/
+TEST_FUNCTION(IgnoreAllCalls_does_not_record_an_expected_call)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(test_dependency_no_args())
+        .IgnoreAllCalls();
+
+    // act
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_expected_calls());
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_UMOCK_C_LIB_01_101: [The IgnoreAllCalls call modifier shall record that all calls matching the expected call shall be ignored. ]*/
+/* Tests_SRS_UMOCK_C_LIB_01_208: [ If no matching call occurs no missing call shall be reported. ]*/
+TEST_FUNCTION(IgnoreAllCalls_ignores_the_call)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(test_dependency_no_args())
+        .IgnoreAllCalls();
+
+    // act
+    test_dependency_no_args();
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_expected_calls());
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_UMOCK_C_LIB_01_102: [If multiple matching actual calls occur no unexpected calls shall be reported.]*/
+TEST_FUNCTION(IgnoreAllCalls_ignores_2_calls)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(test_dependency_no_args())
+        .IgnoreAllCalls();
+
+    test_dependency_no_args();
+
+    // act
+    test_dependency_no_args();
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_expected_calls());
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_UMOCK_C_LIB_01_102: [If multiple matching actual calls occur no unexpected calls shall be reported.]*/
+/* Tests_SRS_UMOCK_C_LIB_01_103: [The call matching shall be done taking into account arguments and call modifiers referring to arguments.]*/
+TEST_FUNCTION(IgnoreAllCalls_ignores_2_calls_with_matching_1_arg)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(test_dependency_1_arg(42))
+        .IgnoreAllCalls();
+
+    test_dependency_1_arg(42);
+
+    // act
+    test_dependency_1_arg(42);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_expected_calls());
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_UMOCK_C_LIB_01_102: [If multiple matching actual calls occur no unexpected calls shall be reported.]*/
+/* Tests_SRS_UMOCK_C_LIB_01_103: [The call matching shall be done taking into account arguments and call modifiers referring to arguments.]*/
+TEST_FUNCTION(IgnoreAllCalls_ignores_only_calls_with_matching_args)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(test_dependency_1_arg(42))
+        .IgnoreAllCalls();
+
+    test_dependency_1_arg(42);
+
+    // act
+    test_dependency_1_arg(43);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_expected_calls());
+    ASSERT_ARE_EQUAL(char_ptr, "[test_dependency_1_arg(43)]", umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_UMOCK_C_LIB_01_102: [If multiple matching actual calls occur no unexpected calls shall be reported.]*/
+/* Tests_SRS_UMOCK_C_LIB_01_103: [The call matching shall be done taking into account arguments and call modifiers referring to arguments.]*/
+TEST_FUNCTION(IgnoreAllCalls_ignores_only_calls_with_matching_args_2)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(test_dependency_1_arg(42))
+        .IgnoreAllCalls();
+    STRICT_EXPECTED_CALL(test_dependency_1_arg(43));
+
+    // act
+    test_dependency_1_arg(42);
+    test_dependency_1_arg(43);
+    test_dependency_1_arg(42);
+    test_dependency_1_arg(43);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_expected_calls());
+    ASSERT_ARE_EQUAL(char_ptr, "[test_dependency_1_arg(43)]", umock_c_get_actual_calls());
+}
+
 END_TEST_SUITE(umock_c_integrationtests)

--- a/tests/umockcall_ut/umockcall_ut.c
+++ b/tests/umockcall_ut/umockcall_ut.c
@@ -736,7 +736,6 @@ TEST_FUNCTION(umockcall_clone_clones_the_call)
     umockcall_destroy(result);
 }
 
-#if 0
 /* Tests_SRS_UMOCKCALL_01_032: [ If umockcall is NULL, umockcall_clone shall return NULL. ]*/
 TEST_FUNCTION(umockcall_clone_with_NULL_handle_returns_NULL)
 {
@@ -896,7 +895,7 @@ TEST_FUNCTION(umockcall_set_fail_call_with_NULL_fails)
 }
 
 /* Tests_SRS_UMOCKCALL_01_040: [ If a value different than 0 and 1 is passed as fail_call, umockcall_set_fail_call shall return a non-zero value. ]*/
-TEST_FUNCTION(umockcall_set_fail_call_with_an_invalid_fail_Call_value_fails)
+TEST_FUNCTION(umockcall_set_fail_call_with_an_invalid_fail_call_value_fails)
 {
     // arrange
     UMOCKCALL_HANDLE call = umockcall_create("test_function", (void*)0x4242, test_mock_call_data_copy, test_mock_call_data_free, test_mock_call_data_stringify, test_mock_call_data_are_equal);
@@ -998,6 +997,141 @@ TEST_FUNCTION(umockcall_get_fail_call_on_a_cloned_call_retrieves_0)
     umockcall_destroy(call);
     umockcall_destroy(cloned_call);
 }
-#endif
+
+/* umockcall_set_ignore_all_calls */
+
+/* Tests_SRS_UMOCKCALL_01_045: [ umockcall_set_ignore_all_calls shall store the ignore_all_calls value, associating it with the umockcall call instance. ]*/
+/* Tests_SRS_UMOCKCALL_01_046: [ On success umockcall_set_ignore_all_calls shall return 0. ]*/
+TEST_FUNCTION(umockcall_set_ignore_all_calls_sets_the_ignore_all_calls_property)
+{
+    // arrange
+    UMOCKCALL_HANDLE call = umockcall_create("test_function", (void*)0x4242, test_mock_call_data_copy, test_mock_call_data_free, test_mock_call_data_stringify, test_mock_call_data_are_equal);
+
+    // act
+    int result = umockcall_set_ignore_all_calls(call, 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 1, umockcall_get_ignore_all_calls(call));
+
+    // cleanup
+    umockcall_destroy(call);
+}
+
+/* Tests_SRS_UMOCKCALL_01_047: [ If umockcall is NULL, umockcall_set_ignore_all_calls shall return a non-zero value. ]*/
+TEST_FUNCTION(umockcall_set_ignore_all_calls_with_NULL_fails)
+{
+    // arrange
+
+    // act
+    int result = umockcall_set_ignore_all_calls(NULL, 1);
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+}
+
+/* Tests_SRS_UMOCKCALL_01_048: [ If a value different than 0 and 1 is passed as ignore_all_calls, umockcall_set_ignore_all_calls shall return a non-zero value. ]*/
+TEST_FUNCTION(umockcall_set_ignore_all_calls_with_an_invalid_ignore_all_calls_value_fails)
+{
+    // arrange
+    UMOCKCALL_HANDLE call = umockcall_create("test_function", (void*)0x4242, test_mock_call_data_copy, test_mock_call_data_free, test_mock_call_data_stringify, test_mock_call_data_are_equal);
+
+    // act
+    int result = umockcall_set_ignore_all_calls(call, 2);
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+
+    // cleanup
+    umockcall_destroy(call);
+}
+
+/* umockcall_get_ignore_all_calls */
+
+/* Tests_SRS_UMOCKCALL_01_049: [ umockcall_get_ignore_all_calls shall retrieve the ignore_all_calls value, associated with the umockcall call instance. ]*/
+TEST_FUNCTION(umockcall_get_ignore_all_calls_retrieves_0)
+{
+    // arrange
+    UMOCKCALL_HANDLE call = umockcall_create("test_function", (void*)0x4242, test_mock_call_data_copy, test_mock_call_data_free, test_mock_call_data_stringify, test_mock_call_data_are_equal);
+    (void)umockcall_set_ignore_all_calls(call, 0);
+
+    // act
+    int result = umockcall_get_ignore_all_calls(call);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 0, result);
+
+    // cleanup
+    umockcall_destroy(call);
+}
+
+/* Tests_SRS_UMOCKCALL_01_049: [ umockcall_get_ignore_all_calls shall retrieve the ignore_all_calls value, associated with the umockcall call instance. ]*/
+TEST_FUNCTION(umockcall_get_ignore_all_calls_retrieves_1)
+{
+    // arrange
+    UMOCKCALL_HANDLE call = umockcall_create("test_function", (void*)0x4242, test_mock_call_data_copy, test_mock_call_data_free, test_mock_call_data_stringify, test_mock_call_data_are_equal);
+    (void)umockcall_set_ignore_all_calls(call, 1);
+
+    // act
+    int result = umockcall_get_ignore_all_calls(call);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 1, result);
+
+    // cleanup
+    umockcall_destroy(call);
+}
+
+/* Tests_SRS_UMOCKCALL_01_050: [ If umockcall is NULL, umockcall_get_ignore_all_calls shall return -1. ]*/
+TEST_FUNCTION(umockcall_get_ignore_all_calls_with_NULL_call_fails)
+{
+    // arrange
+
+    // act
+    int result = umockcall_get_ignore_all_calls(NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, -1, result);
+}
+
+/* Tests_SRS_UMOCKCALL_01_041: [ umockcall_get_fail_call shall retrieve the fail_call value, associated with the umockcall call instance. ]*/
+TEST_FUNCTION(umockcall_get_ignore_all_calls_on_a_cloned_call_retrieves_1)
+{
+    // arrange
+    UMOCKCALL_HANDLE call = umockcall_create("test_function", (void*)0x4242, test_mock_call_data_copy, test_mock_call_data_free, test_mock_call_data_stringify, test_mock_call_data_are_equal);
+    (void)umockcall_set_ignore_all_calls(call, 1);
+    test_mock_call_data_copy_expected_result = (void*)0x4243;
+    UMOCKCALL_HANDLE cloned_call = umockcall_clone(call);
+
+    // act
+    int result = umockcall_get_ignore_all_calls(cloned_call);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 1, result);
+
+    // cleanup
+    umockcall_destroy(call);
+    umockcall_destroy(cloned_call);
+}
+
+/* Tests_SRS_UMOCKCALL_01_049: [ umockcall_get_ignore_all_calls shall retrieve the ignore_all_calls value, associated with the umockcall call instance. ]*/
+TEST_FUNCTION(umockcall_get_ignore_all_calls_on_a_cloned_call_retrieves_0)
+{
+    // arrange
+    UMOCKCALL_HANDLE call = umockcall_create("test_function", (void*)0x4242, test_mock_call_data_copy, test_mock_call_data_free, test_mock_call_data_stringify, test_mock_call_data_are_equal);
+    (void)umockcall_set_fail_call(call, 0);
+    test_mock_call_data_copy_expected_result = (void*)0x4243;
+    UMOCKCALL_HANDLE cloned_call = umockcall_clone(call);
+
+    // act
+    int result = umockcall_get_fail_call(cloned_call);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 0, result);
+
+    // cleanup
+    umockcall_destroy(call);
+    umockcall_destroy(cloned_call);
+}
 
 END_TEST_SUITE(umockcall_unittests)


### PR DESCRIPTION
Implement IgnoreAllCalls call modifier:
- Update umockcall specs, tests and code to account for the call property ignore_all_calls
- Update umockcallrecorder to have the ignore logic
- Update the umock_c_internal header to generate the IgnoreAllCalls call modifier