### PR TITLE
Fix cast in track paired calls delete in order to be able to use volatile args

### DIFF
--- a/inc/umock_c_internal.h
+++ b/inc/umock_c_internal.h
@@ -126,10 +126,10 @@ typedef int(*TRACK_DESTROY_FUNC_TYPE)(PAIRED_HANDLES* paired_handles, const void
 #define STRINGIFY_ARGS_DECLARE_RESULT_VAR(count, arg_type, arg_name) \
     char* C2(arg_name,_stringified) \
     = (C2(typed_mock_call_data->validate_arg_value_pointer_, arg_name) != NULL) ? \
-      umocktypes_stringify(TOSTRING(arg_type), C2(typed_mock_call_data->validate_arg_value_pointer_, arg_name)) : \
+      umocktypes_stringify(TOSTRING(arg_type), (void*)C2(typed_mock_call_data->validate_arg_value_pointer_, arg_name)) : \
       ((typed_mock_call_data->validate_arg_buffers[COUNT_OF(typed_mock_call_data->out_arg_buffers) - DIV2(count)].bytes != NULL) ? \
         umockc_stringify_buffer(typed_mock_call_data->validate_arg_buffers[COUNT_OF(typed_mock_call_data->validate_arg_buffers) - DIV2(count)].bytes, typed_mock_call_data->validate_arg_buffers[COUNT_OF(typed_mock_call_data->validate_arg_buffers) - DIV2(count)].length) : \
-        umocktypes_stringify(TOSTRING(arg_type), &typed_mock_call_data->arg_name));
+        umocktypes_stringify(TOSTRING(arg_type), (void*)&typed_mock_call_data->arg_name));
 
 #define STRINGIFY_ARGS_CHECK_ARG_STRINGIFY_SUCCESS(arg_type, arg_name) if (C2(arg_name,_stringified) == NULL) is_error = 1;
 #define STRINGIFY_ARGS_DECLARE_ARG_STRING_LENGTH(arg_type, arg_name) size_t C2(arg_name,_stringified_length) = strlen(C2(arg_name,_stringified));
@@ -1216,7 +1216,7 @@ typedef struct MOCK_CALL_METADATA_TAG
         } \
         IF(COUNT_ARG(__VA_ARGS__), if (C2(track_create_destroy_pair_free_, name) != NULL) \
         { \
-            if (C2(track_create_destroy_pair_free_, name)(C2(used_paired_handles_, name), &ONLY_FIRST_ARG(__VA_ARGS__, 1)) != 0) \
+            if (C2(track_create_destroy_pair_free_, name)(C2(used_paired_handles_, name), (void*)&ONLY_FIRST_ARG(__VA_ARGS__, 1)) != 0) \
             { \
                 UMOCK_LOG("Could not track the destroy call for %s.", TOSTRING(name)); \
                 umock_c_indicate_error(UMOCK_C_ERROR); \

--- a/tests/umock_c_int/test_dependency.h
+++ b/tests/umock_c_int/test_dependency.h
@@ -62,6 +62,8 @@ extern "C" {
     MOCKABLE_FUNCTION(, void, test_dependency_with_void_ptr, void*, argument);
     MOCKABLE_FUNCTION(, void, test_dependency_with_const_void_ptr, const void*, argument);
     MOCKABLE_FUNCTION(, void, test_dependency_with_array_arg, ARRAY_TYPE, argument);
+    MOCKABLE_FUNCTION(, void, test_dependency_with_volatile_arg, volatile int, argument);
+    MOCKABLE_FUNCTION(, void, test_dependency_with_volatile_pointer_arg, int volatile*, argument);
 
     typedef enum TEST_ENUM_TAG
     {

--- a/tests/umock_c_int/umock_c_int.c
+++ b/tests/umock_c_int/umock_c_int.c
@@ -327,6 +327,10 @@ MOCK_FUNCTION_WITH_CODE(, SOME_STRUCT, some_create_with_struct, int, a);
 MOCK_FUNCTION_END(test_struct)
 MOCK_FUNCTION_WITH_CODE(, void, some_destroy_with_struct, SOME_STRUCT, s);
 MOCK_FUNCTION_END()
+MOCK_FUNCTION_WITH_CODE(, void, mock_function_with_code_with_volatile_arg, volatile int, a);
+MOCK_FUNCTION_END()
+MOCK_FUNCTION_WITH_CODE(, void, mock_function_with_code_with_volatile_pointer_arg, int volatile*, a);
+MOCK_FUNCTION_END()
 
 BEGIN_TEST_SUITE(umock_c_integrationtests)
 


### PR DESCRIPTION
Fix cast in track paired calls delete in order to be able to use volatile args