### PR TITLE
Remove/Replace non-ascii chars in code and markdown

### DIFF
--- a/devdoc/umock_c_lib_requirements_with_ids.md
+++ b/devdoc/umock_c_lib_requirements_with_ids.md
@@ -1,6 +1,6 @@
 
 # umock_c
- 
+
 # Overview
 
 umock_c is a C mocking library that exposes APIs to allow:
@@ -13,9 +13,9 @@ On top of the basic functionality, additional convenience features like modifier
 
 A test written with umock_c looks like below:
 
-Let’s assume unit A depends on unit B. unit B has a function called test_dependency_1_arg.
+Let's assume unit A depends on unit B. unit B has a function called test_dependency_1_arg.
 
-In unit B’s header one would write:
+In unit B's header one would write:
 
 ```c
 #include "umock_prod.h"
@@ -23,7 +23,7 @@ In unit B’s header one would write:
 MOCKABLE_FUNCTION(int, test_dependency_1_arg, int, a);
 ```
 
-Let’s assume unit A has a function called function_under_test.
+Let's assume unit A has a function called function_under_test.
 
 ```c
 int function_under_test();
@@ -881,7 +881,7 @@ REGISTER_GLOBAL_MOCK_HOOK(mock_function, mock_hook_function)
 ```
 
 XX**SRS_UMOCK_C_LIB_01_104: [** The REGISTER_GLOBAL_MOCK_HOOK shall register a mock hook to be called every time the mocked function is called by production code. **]**
-XX**SRS_UMOCK_C_LIB_01_105: [** The hook’s result shall be returned by the mock to the production code. **]**
+XX**SRS_UMOCK_C_LIB_01_105: [** The hook's result shall be returned by the mock to the production code. **]**
 
 XX**SRS_UMOCK_C_LIB_01_106: [** The signature for the hook shall be assumed to have exactly the same arguments and return as the mocked function. **]**
 

--- a/devdoc/umock_c_negative_tests_requirements.md
+++ b/devdoc/umock_c_negative_tests_requirements.md
@@ -1,5 +1,5 @@
 # umock_c_negative_tests requirements
- 
+
 # Overview
 
 umock_c_negative_tests is an addon to umock_c that exposes APIs used to automate negative tests.

--- a/devdoc/umock_c_requirements.md
+++ b/devdoc/umock_c_requirements.md
@@ -1,5 +1,5 @@
 # umock_c requirements
- 
+
 # Overview
 
 umock_c is a module that exposes the user facing API for umock_c.

--- a/devdoc/umockalloc_requirements.md
+++ b/devdoc/umockalloc_requirements.md
@@ -1,5 +1,5 @@
 # umockalloc requirements
- 
+
 # Overview
 
 umockalloc is a module that wraps the C memory allocation functions (malloc, realloc and free).

--- a/devdoc/umockautoignoreargs_requirements.md
+++ b/devdoc/umockautoignoreargs_requirements.md
@@ -1,5 +1,5 @@
 ﻿# umockautoignoreargs requirements
- 
+
 # Overview
 
 `umockautoignoreargs` is a module that provides the functionality of inspecting the arguments of a function to determine whether they should be ignored or not.

--- a/devdoc/umockcall_requirements.md
+++ b/devdoc/umockcall_requirements.md
@@ -1,5 +1,5 @@
 # umockcall requirements
- 
+
 # Overview
 
 umockcall is a module that encapsulates a umock call.

--- a/devdoc/umockcallrecorder_requirements.md
+++ b/devdoc/umockcallrecorder_requirements.md
@@ -1,6 +1,6 @@
 
 # umockcallrecorder requirements
- 
+
 # Overview
 
 umockcallrecorder is a module that implements recording the expected and actual calls.

--- a/devdoc/umockstring_requirements.md
+++ b/devdoc/umockstring_requirements.md
@@ -1,6 +1,6 @@
 
 ﻿# umockstring requirements
- 
+
 # Overview
 
 umockstring is a module that provides the functionality of cloning a string (allocating memory and copying the chars).

--- a/devdoc/umocktypename_requirements.md
+++ b/devdoc/umocktypename_requirements.md
@@ -1,6 +1,6 @@
 
 # umocktypename requirements
- 
+
 # Overview
 
 umocktypename is a module that provides a way to bring C type names to a normalized form in order to ensure that type name comparisons can be made easily.

--- a/devdoc/umocktypes_bool_requirements.md
+++ b/devdoc/umocktypes_bool_requirements.md
@@ -1,6 +1,6 @@
 
 ﻿# umocktypes_bool requirements
- 
+
 # Overview
 
 umocktypes_c is a module that exposes out of the box functionality for bool and \_Bool for umock_c.

--- a/devdoc/umocktypes_charptr_requirements.md
+++ b/devdoc/umocktypes_charptr_requirements.md
@@ -1,6 +1,6 @@
 
 # umocktypes_charptr requirements
- 
+
 # Overview
 
 umocktypes_charptr is a module that exposes out of the box functionality for char\* and const char\* types for umockc.

--- a/devdoc/umocktypes_requirements.md
+++ b/devdoc/umocktypes_requirements.md
@@ -1,6 +1,6 @@
 
 # umocktypes requirements
- 
+
 # Overview
 
 umocktypes is a module that exposes a generic type interface to be used by umockc for registering various C types. Later operations are possible with these types, specifically: converting any type value to a string, comparing values, copying and freeing values.

--- a/devdoc/umocktypes_stdint_requirements.md
+++ b/devdoc/umocktypes_stdint_requirements.md
@@ -1,6 +1,6 @@
 
 # umocktypes_stdint requirements
- 
+
 # Overview
 
 umocktypes_stdint is a module that exposes out of the box functionality for types defined in stdint in C99.

--- a/doc/umock_c.md
+++ b/doc/umock_c.md
@@ -1,5 +1,5 @@
 ﻿# umock_c
- 
+
 # Overview
 
 umock_c is a C mocking library that exposes APIs to allow:
@@ -12,9 +12,9 @@ On top of the basic functionality, additional convenience features like modifier
 
 A test written with umock_c looks like below:
 
-Let’s assume unit A depends on unit B. unit B has a function called test_dependency_1_arg.
+Let's assume unit A depends on unit B. unit B has a function called test_dependency_1_arg.
 
-In unit B’s header one would write:
+In unit B's header one would write:
 
 ```c
 #include "umock_prod.h"
@@ -22,7 +22,7 @@ In unit B’s header one would write:
 MOCKABLE_FUNCTION(, int, test_dependency_1_arg, int, a);
 ```
 
-Let’s assume unit A has a function called function_under_test.
+Let's assume unit A has a function called function_under_test.
 
 ```c
 int function_under_test();
@@ -891,7 +891,7 @@ is equivalent to:
 REGISTER_GLOBAL_MOCK_HOOK(mock_function, mock_hook_function)
 ```
 
-The REGISTER_GLOBAL_MOCK_HOOK shall register a mock hook to be called every time the mocked function is called by production code. The hook’s result shall be returned by the mock to the production code.
+The REGISTER_GLOBAL_MOCK_HOOK shall register a mock hook to be called every time the mocked function is called by production code. The hook's result shall be returned by the mock to the production code.
 
 The signature for the hook shall be assumed to have exactly the same arguments and return as the mocked function.
 

--- a/tests/umock_c_int/umock_c_int.c
+++ b/tests/umock_c_int/umock_c_int.c
@@ -1695,7 +1695,7 @@ TEST_FUNCTION(When_ValidateArgumentBuffer_is_called_twice_the_last_buffer_is_use
 /* REGISTER_GLOBAL_MOCK_HOOK */
 
 /* Tests_SRS_UMOCK_C_LIB_01_104: [The REGISTER_GLOBAL_MOCK_HOOK shall register a mock hook to be called every time the mocked function is called by production code.]*/
-/* Tests_SRS_UMOCK_C_LIB_01_105: [The hook’s result shall be returned by the mock to the production code.]*/
+/* Tests_SRS_UMOCK_C_LIB_01_105: [The hook's result shall be returned by the mock to the production code.]*/
 /* Tests_SRS_UMOCK_C_LIB_01_106: [The signature for the hook shall be assumed to have exactly the same arguments and return as the mocked function.]*/
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_registers_a_hook_for_the_mock)
 {
@@ -1711,7 +1711,7 @@ TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_registers_a_hook_for_the_mock)
 }
 
 /* Tests_SRS_UMOCK_C_LIB_01_104: [The REGISTER_GLOBAL_MOCK_HOOK shall register a mock hook to be called every time the mocked function is called by production code.]*/
-/* Tests_SRS_UMOCK_C_LIB_01_105: [The hook’s result shall be returned by the mock to the production code.]*/
+/* Tests_SRS_UMOCK_C_LIB_01_105: [The hook's result shall be returned by the mock to the production code.]*/
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_registers_a_hook_for_the_mock_that_returns_2_different_values)
 {
     // arrange


### PR DESCRIPTION
Customers on ja-JP Windows (and others) can get errors when compiling, because their codepage doesn't support some of the Unicode chars that have made their way into the code comments. This change removes/replaces the Unicode chars.