### PR TITLE
Fix cmake error when only '-Drun_int_tests' is specified

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 2.8.11)
 
-if (${run_unittests})
+if (${run_unittests} OR ${run_int_tests})
 	add_subdirectory(ctest)
 	add_subdirectory(testrunner)
 endif()


### PR DESCRIPTION
The following command fails today:

```
cmake -Drun_int_tests=ON ..
```

You have to run this command if you want to build the integration tests:

```
cmake -D run_unittests -Drun_int_tests=ON ..
```

This change makes the former command possible.