### PR TITLE
Fix problems for VS2008

### DIFF
--- a/inc/umock_c_internal.h
+++ b/inc/umock_c_internal.h
@@ -748,8 +748,8 @@ typedef int(*TRACK_DESTROY_FUNC_TYPE)(PAIRED_HANDLES* paired_handles, const void
 #define IMPLEMENT_SET_CALL_CANNOT_FAIL(return_type, name, ...) \
         static C2(mock_call_modifier_,name) C2(call_cannot_fail_func_,name)(void) \
         { \
-            DECLARE_MOCK_CALL_MODIFIER(name) \
             UMOCKCALL_HANDLE last_expected_call = umock_c_get_last_expected_call(); \
+            DECLARE_MOCK_CALL_MODIFIER(name) \
             if (last_expected_call == NULL) \
             { \
                 UMOCK_LOG("Cannot get last expected call."); \

--- a/jenkins/windows_vs2008_c.cmd
+++ b/jenkins/windows_vs2008_c.cmd
@@ -35,7 +35,7 @@ rem no error checking
 pushd %build-root%\cmake\%CMAKE_DIR%
 
 echo ***Running CMAKE for Win32***   
-cmake %build-root% -Drun_unittests:BOOL=ON
+cmake %build-root% -Drun_unittests:BOOL=ON -Drun_int_tests:bool=ON
 if not !ERRORLEVEL!==0 exit /b !ERRORLEVEL!
 
 call :_run-msbuild "Build" umock_c.sln

--- a/tests/umock_c_int/umock_c_int.c
+++ b/tests/umock_c_int/umock_c_int.c
@@ -1043,11 +1043,12 @@ TEST_FUNCTION(ValidateArgument_by_index_with_index_greater_than_arg_count_trigge
 TEST_FUNCTION(SetReturn_sets_the_return_value_for_a_strict_expected_call)
 {
     // arrange
+    int result;
     STRICT_EXPECTED_CALL(test_dependency_no_args())
         .SetReturn(42);
 
     // act
-    int result = test_dependency_no_args();
+    result = test_dependency_no_args();
 
     // assert
     ASSERT_ARE_EQUAL(int, 42, result);
@@ -1059,11 +1060,12 @@ TEST_FUNCTION(SetReturn_sets_the_return_value_for_a_strict_expected_call)
 TEST_FUNCTION(SetReturn_sets_the_return_value_for_an_expected_call)
 {
     // arrange
+    int result;
     EXPECTED_CALL(test_dependency_no_args())
         .SetReturn(42);
 
     // act
-    int result = test_dependency_no_args();
+    result = test_dependency_no_args();
 
     // assert
     ASSERT_ARE_EQUAL(int, 42, result);
@@ -1075,11 +1077,12 @@ TEST_FUNCTION(SetReturn_sets_the_return_value_for_an_expected_call)
 TEST_FUNCTION(SetReturn_sets_the_return_value_only_for_a_matched_call)
 {
     // arrange
+    int result;
     STRICT_EXPECTED_CALL(test_dependency_1_arg(42))
         .SetReturn(42);
 
     // act
-    int result = test_dependency_1_arg(41);
+    result = test_dependency_1_arg(41);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -1089,14 +1092,16 @@ TEST_FUNCTION(SetReturn_sets_the_return_value_only_for_a_matched_call)
 TEST_FUNCTION(SetReturn_sets_independent_return_values_for_each_call)
 {
     // arrange
+    int result1;
+    int result2;
     STRICT_EXPECTED_CALL(test_dependency_1_arg(42))
         .SetReturn(142);
     STRICT_EXPECTED_CALL(test_dependency_1_arg(43))
         .SetReturn(143);
 
     // act
-    int result1 = test_dependency_1_arg(42);
-    int result2 = test_dependency_1_arg(43);
+    result1 = test_dependency_1_arg(42);
+    result2 = test_dependency_1_arg(43);
 
     // assert
     ASSERT_ARE_EQUAL(int, 142, result1);
@@ -1700,11 +1705,12 @@ TEST_FUNCTION(When_ValidateArgumentBuffer_is_called_twice_the_last_buffer_is_use
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_registers_a_hook_for_the_mock)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_HOOK(test_dependency_no_args, my_hook_test_dependency_no_args);
     my_hook_result = 0x42;
 
     // act
-    int result = test_dependency_no_args();
+    result = test_dependency_no_args();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0x42, result);
@@ -1731,12 +1737,13 @@ TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_registers_a_hook_for_the_mock_that_retur
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_twice_makes_the_last_hook_stick)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_HOOK(test_dependency_no_args, my_hook_test_dependency_no_args);
     REGISTER_GLOBAL_MOCK_HOOK(test_dependency_no_args, my_hook_test_dependency_no_args_2);
     my_hook_result = 0x42;
 
     // act
-    int result = test_dependency_no_args();
+    result = test_dependency_no_args();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0x21, result);
@@ -1746,11 +1753,12 @@ TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_twice_makes_the_last_hook_stick)
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_with_NULL_unregisters_a_previously_registered_hook)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_HOOK(test_dependency_no_args, my_hook_test_dependency_no_args);
     REGISTER_GLOBAL_MOCK_HOOK(test_dependency_no_args, NULL);
 
     // act
-    int result = test_dependency_no_args();
+    result = test_dependency_no_args();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -1789,10 +1797,11 @@ TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_with_a_function_that_returns_void_works)
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_RETURN_makes_a_subsequent_call_to_the_mock_return_the_value)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_RETURN(test_dependency_global_mock_return_test, 0x45);
 
     // act
-    int result = test_dependency_global_mock_return_test();
+    result = test_dependency_global_mock_return_test();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0x45, result);
@@ -1802,11 +1811,12 @@ TEST_FUNCTION(REGISTER_GLOBAL_MOCK_RETURN_makes_a_subsequent_call_to_the_mock_re
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_RETURN_twice_only_makes_the_second_call_stick)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_RETURN(test_dependency_global_mock_return_test, 0x45);
     REGISTER_GLOBAL_MOCK_RETURN(test_dependency_global_mock_return_test, 0x46);
 
     // act
-    int result = test_dependency_global_mock_return_test();
+    result = test_dependency_global_mock_return_test();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0x46, result);
@@ -1818,11 +1828,12 @@ TEST_FUNCTION(REGISTER_GLOBAL_MOCK_RETURN_twice_only_makes_the_second_call_stick
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_FAIL_RETURN_is_possible_and_does_not_affect_the_return_value)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_RETURN(test_dependency_global_mock_return_test, 0x42);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(test_dependency_global_mock_return_test, 0x45);
 
     // act
-    int result = test_dependency_global_mock_return_test();
+    result = test_dependency_global_mock_return_test();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0x42, result);
@@ -1832,12 +1843,13 @@ TEST_FUNCTION(REGISTER_GLOBAL_MOCK_FAIL_RETURN_is_possible_and_does_not_affect_t
 TEST_FUNCTION(Multiple_REGISTER_GLOBAL_MOCK_FAIL_RETURN_calls_are_possible)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_RETURN(test_dependency_global_mock_return_test, 0x42);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(test_dependency_global_mock_return_test, 0x45);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(test_dependency_global_mock_return_test, 0x46);
 
     // act
-    int result = test_dependency_global_mock_return_test();
+    result = test_dependency_global_mock_return_test();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0x42, result);
@@ -1847,11 +1859,12 @@ TEST_FUNCTION(Multiple_REGISTER_GLOBAL_MOCK_FAIL_RETURN_calls_are_possible)
 TEST_FUNCTION(When_copy_fails_in_REGISTER_GLOBAL_MOCK_FAIL_RETURN_then_on_error_is_triggered)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_RETURN(test_dependency_global_mock_return_test, 0x42);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(test_dependency_global_mock_return_test, 0x45);
 
     // act
-    int result = test_dependency_global_mock_return_test();
+    result = test_dependency_global_mock_return_test();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0x42, result);
@@ -1863,10 +1876,11 @@ TEST_FUNCTION(When_copy_fails_in_REGISTER_GLOBAL_MOCK_FAIL_RETURN_then_on_error_
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_RETURNS_registers_the_return_value)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_RETURNS(test_dependency_global_mock_return_test, 0xAA, 0x43);
 
     // act
-    int result = test_dependency_global_mock_return_test();
+    result = test_dependency_global_mock_return_test();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0xAA, result);
@@ -1876,11 +1890,12 @@ TEST_FUNCTION(REGISTER_GLOBAL_MOCK_RETURNS_registers_the_return_value)
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_RETURNS_twice_makes_only_the_last_call_stick)
 {
     // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_RETURNS(test_dependency_global_mock_return_test, 0xAA, 0x43);
     REGISTER_GLOBAL_MOCK_RETURNS(test_dependency_global_mock_return_test, 0xAB, 0x44);
 
     // act
-    int result = test_dependency_global_mock_return_test();
+    result = test_dependency_global_mock_return_test();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0xAB, result);
@@ -1980,11 +1995,12 @@ TEST_FUNCTION(when_a_type_is_not_supported_an_error_is_triggered)
 TEST_FUNCTION(when_the_return_value_is_given_by_SetReturn_then_it_is_returned)
 {
     // arrange
+    int result;
     STRICT_EXPECTED_CALL(test_dependency_1_arg(42))
         .SetReturn(42);
 
     // act
-    int result = test_dependency_1_arg(42);
+    result = test_dependency_1_arg(42);
 
     // assert
     ASSERT_ARE_EQUAL(int, 42, result);
@@ -1995,14 +2011,16 @@ TEST_FUNCTION(when_the_return_value_is_given_by_SetReturn_then_it_is_returned)
 /* Tests_SRS_UMOCK_C_LIB_01_138: [ - If a global mock hook has been specified then it shall be called and its result returned. ]*/
 TEST_FUNCTION(when_the_return_value_is_given_by_SetReturn_for_a_function_with_a_global_return_hook_the_SetReturn_value_is_returned)
 {
+    // arrange
+    int result;
+
     REGISTER_GLOBAL_MOCK_HOOK(test_dependency_with_global_mock_hook, my_hook_test_dependency_with_global_mock_hook);
 
-    // arrange
     STRICT_EXPECTED_CALL(test_dependency_with_global_mock_hook())
         .SetReturn(42);
 
     // act
-    int result = test_dependency_with_global_mock_hook();
+    result = test_dependency_with_global_mock_hook();
 
     // assert
     ASSERT_ARE_EQUAL(int, 42, result);
@@ -2013,13 +2031,13 @@ TEST_FUNCTION(when_the_return_value_is_given_by_SetReturn_for_a_function_with_a_
 /* Tests_SRS_UMOCK_C_LIB_01_138: [ - If a global mock hook has been specified then it shall be called and its result returned. ]*/
 TEST_FUNCTION(when_the_return_value_is_not_given_by_SetReturn_for_a_function_with_a_global_return_hook_the_mock_hook_return_value_is_returned)
 {
-    REGISTER_GLOBAL_MOCK_HOOK(test_dependency_with_global_mock_hook, my_hook_test_dependency_with_global_mock_hook);
-
     // arrange
+    int result;
+    REGISTER_GLOBAL_MOCK_HOOK(test_dependency_with_global_mock_hook, my_hook_test_dependency_with_global_mock_hook);
     STRICT_EXPECTED_CALL(test_dependency_with_global_mock_hook());
 
     // act
-    int result = test_dependency_with_global_mock_hook();
+    result = test_dependency_with_global_mock_hook();
 
     // assert
     ASSERT_ARE_EQUAL(int, 43, result);
@@ -2028,15 +2046,15 @@ TEST_FUNCTION(when_the_return_value_is_not_given_by_SetReturn_for_a_function_wit
 /* Tests_SRS_UMOCK_C_LIB_01_139: [ - If a global return value has been specified then it shall be returned. ]*/
 TEST_FUNCTION(when_the_return_value_is_given_by_SetReturn_for_a_function_with_a_global_return_hook_and_global_return_the_SetReturn_value_is_returned)
 {
+    // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_HOOK(test_dependency_with_global_mock_hook, my_hook_test_dependency_with_global_mock_hook);
     REGISTER_GLOBAL_MOCK_RETURN(test_dependency_with_global_mock_hook, 44);
-
-    // arrange
     STRICT_EXPECTED_CALL(test_dependency_with_global_mock_hook())
         .SetReturn(42);
 
     // act
-    int result = test_dependency_with_global_mock_hook();
+    result = test_dependency_with_global_mock_hook();
 
     // assert
     ASSERT_ARE_EQUAL(int, 42, result);
@@ -2045,14 +2063,15 @@ TEST_FUNCTION(when_the_return_value_is_given_by_SetReturn_for_a_function_with_a_
 /* Tests_SRS_UMOCK_C_LIB_01_139: [ - If a global return value has been specified then it shall be returned. ]*/
 TEST_FUNCTION(when_the_return_value_is_not_given_by_SetReturn_for_a_function_with_a_global_return_hook_and_global_return_the_global_mock_hook_value_is_returned)
 {
+    // arrange
+    int result;
     REGISTER_GLOBAL_MOCK_HOOK(test_dependency_with_global_mock_hook, my_hook_test_dependency_with_global_mock_hook);
     REGISTER_GLOBAL_MOCK_RETURN(test_dependency_with_global_mock_hook, 44);
 
-    // arrange
     STRICT_EXPECTED_CALL(test_dependency_with_global_mock_hook());
 
     // act
-    int result = test_dependency_with_global_mock_hook();
+    result = test_dependency_with_global_mock_hook();
 
     // assert
     ASSERT_ARE_EQUAL(int, 43, result);
@@ -2061,13 +2080,13 @@ TEST_FUNCTION(when_the_return_value_is_not_given_by_SetReturn_for_a_function_wit
 /* Tests_SRS_UMOCK_C_LIB_01_139: [ - If a global return value has been specified then it shall be returned. ]*/
 TEST_FUNCTION(when_the_return_value_is_specified_only_by_global_return_that_global_return_value_is_returned)
 {
-    REGISTER_GLOBAL_MOCK_RETURN(test_dependency_with_global_return, 44);
-
     // arrange
+    int result;
+    REGISTER_GLOBAL_MOCK_RETURN(test_dependency_with_global_return, 44);
     STRICT_EXPECTED_CALL(test_dependency_with_global_return());
 
     // act
-    int result = test_dependency_with_global_return();
+    result = test_dependency_with_global_return();
 
     // assert
     ASSERT_ARE_EQUAL(int, 44, result);
@@ -2077,10 +2096,11 @@ TEST_FUNCTION(when_the_return_value_is_specified_only_by_global_return_that_glob
 TEST_FUNCTION(when_no_return_value_is_specified_for_a_function_returning_int_0_is_returned)
 {
     // arrange
+    int result;
     STRICT_EXPECTED_CALL(test_dependency_returning_int());
 
     // act
-    int result = test_dependency_returning_int();
+    result = test_dependency_returning_int();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -2843,11 +2863,12 @@ TEST_FUNCTION(IgnoreAllCalls_ignores_only_calls_with_matching_args_2)
 TEST_FUNCTION(CallCannotFail_sets_cannot_fail_for_strict_expected_call)
 {
     // arrange
+    int result;
     STRICT_EXPECTED_CALL(test_dependency_no_args())
         .CallCannotFail();
 
     // act
-    int result = test_dependency_no_args();
+    result = test_dependency_no_args();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);
@@ -2859,11 +2880,13 @@ TEST_FUNCTION(CallCannotFail_sets_cannot_fail_for_strict_expected_call)
 TEST_FUNCTION(CallCannotFail_sets_cannot_fail_for_expected_call)
 {
     // arrange
+    int result;
+
     EXPECTED_CALL(test_dependency_no_args())
         .CallCannotFail();
 
     // act
-    int result = test_dependency_no_args();
+    result = test_dependency_no_args();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, result);

--- a/tests/umock_c_int/umock_c_int.c
+++ b/tests/umock_c_int/umock_c_int.c
@@ -1116,9 +1116,10 @@ TEST_FUNCTION(CopyOutArgumentBuffer_copies_bytes_to_the_out_argument_for_a_stric
 {
     // arrange
     int injected_int = 0x42;
+    int actual_int = 0;
     STRICT_EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer(1, &injected_int, sizeof(injected_int));
-    int actual_int = 0;
+
 
     // act
     (void)test_dependency_1_out_arg(&actual_int);
@@ -1133,9 +1134,10 @@ TEST_FUNCTION(CopyOutArgumentBuffer_copies_bytes_to_the_out_argument_for_an_expe
 {
     // arrange
     int injected_int = 0x42;
+    int actual_int = 0;
     EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer(1, &injected_int, sizeof(injected_int));
-    int actual_int = 0;
+
 
     // act
     (void)test_dependency_1_out_arg(&actual_int);
@@ -1150,10 +1152,11 @@ TEST_FUNCTION(CopyOutArgumentBuffer_only_copies_bytes_to_the_out_argument_that_w
 {
     // arrange
     int injected_int = 0x42;
-    EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .CopyOutArgumentBuffer(1, &injected_int, sizeof(injected_int));
     int actual_int_1 = 0;
     int actual_int_2 = 0;
+    EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .CopyOutArgumentBuffer(1, &injected_int, sizeof(injected_int));
+
 
     // act
     (void)test_dependency_2_out_args(&actual_int_1, &actual_int_2);
@@ -1169,10 +1172,10 @@ TEST_FUNCTION(CopyOutArgumentBuffer_only_copies_bytes_to_the_second_out_argument
 {
     // arrange
     int injected_int = 0x42;
-    EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .CopyOutArgumentBuffer(2, &injected_int, sizeof(injected_int));
     int actual_int_1 = 0;
     int actual_int_2 = 0;
+    EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .CopyOutArgumentBuffer(2, &injected_int, sizeof(injected_int));
 
     // act
     (void)test_dependency_2_out_args(&actual_int_1, &actual_int_2);
@@ -1187,9 +1190,10 @@ TEST_FUNCTION(CopyOutArgumentBuffer_copies_the_memory_for_later_use)
 {
     // arrange
     int injected_int = 0x42;
+    int actual_int = 0;
     EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer(1, &injected_int, sizeof(injected_int));
-    int actual_int = 0;
+
     injected_int = 0;
 
     // act
@@ -1205,10 +1209,10 @@ TEST_FUNCTION(CopyOutArgumentBuffer_frees_allocated_buffers_for_previous_CopyOut
 {
     // arrange
     int injected_int = 0x42;
+    int actual_int = 0;
     EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer(1, &injected_int, sizeof(injected_int))
         .CopyOutArgumentBuffer(1, &injected_int, sizeof(injected_int));
-    int actual_int = 0;
 
     // act
     (void)test_dependency_1_out_arg(&actual_int);
@@ -1283,11 +1287,12 @@ TEST_FUNCTION(CopyOutArgumentBuffer_when_an_error_occurs_preserves_the_previous_
     // arrange
     int injected_int = 0x42;
     int injected_int_2 = 0x43;
+    int actual_int_1 = 0;
+    int actual_int_2 = 0;
     EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer(2, &injected_int, sizeof(injected_int))
         .CopyOutArgumentBuffer(0, &injected_int_2, sizeof(injected_int_2));
-    int actual_int_1 = 0;
-    int actual_int_2 = 0;
+
 
     // act
     (void)test_dependency_2_out_args(&actual_int_1, &actual_int_2);
@@ -1305,9 +1310,10 @@ TEST_FUNCTION(CopyOutArgumentBuffer_arg_name_copies_bytes_to_the_out_argument_fo
 {
     // arrange
     int injected_int = 0x42;
+    int actual_int = 0;
     STRICT_EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer_a(&injected_int, sizeof(injected_int));
-    int actual_int = 0;
+
 
     // act
     (void)test_dependency_1_out_arg(&actual_int);
@@ -1322,9 +1328,9 @@ TEST_FUNCTION(CopyOutArgumentBuffer_arg_name_copies_bytes_to_the_out_argument_fo
 {
     // arrange
     int injected_int = 0x42;
+    int actual_int = 0;
     EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer_a(&injected_int, sizeof(injected_int));
-    int actual_int = 0;
 
     // act
     (void)test_dependency_1_out_arg(&actual_int);
@@ -1339,10 +1345,10 @@ TEST_FUNCTION(CopyOutArgumentBuffer_arg_name_only_copies_bytes_to_the_out_argume
 {
     // arrange
     int injected_int = 0x42;
-    EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .CopyOutArgumentBuffer_a(&injected_int, sizeof(injected_int));
     int actual_int_1 = 0;
     int actual_int_2 = 0;
+    EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .CopyOutArgumentBuffer_a(&injected_int, sizeof(injected_int));
 
     // act
     (void)test_dependency_2_out_args(&actual_int_1, &actual_int_2);
@@ -1358,10 +1364,10 @@ TEST_FUNCTION(CopyOutArgumentBuffer_arg_name_only_copies_bytes_to_the_second_out
 {
     // arrange
     int injected_int = 0x42;
-    EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .CopyOutArgumentBuffer_b(&injected_int, sizeof(injected_int));
     int actual_int_1 = 0;
     int actual_int_2 = 0;
+    EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .CopyOutArgumentBuffer_b(&injected_int, sizeof(injected_int));
 
     // act
     (void)test_dependency_2_out_args(&actual_int_1, &actual_int_2);
@@ -1379,6 +1385,7 @@ TEST_FUNCTION(CopyOutArgumentBuffer_arg_name_copies_the_memory_for_later_use)
     EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer_a(&injected_int, sizeof(injected_int));
     int actual_int = 0;
+
     injected_int = 0;
 
     // act
@@ -1394,10 +1401,10 @@ TEST_FUNCTION(CopyOutArgumentBuffer_arg_name_frees_allocated_buffers_for_previou
 {
     // arrange
     int injected_int = 0x42;
+    int actual_int = 0;
     EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer_a(&injected_int, sizeof(injected_int))
         .CopyOutArgumentBuffer_a(&injected_int, sizeof(injected_int));
-    int actual_int = 0;
 
     // act
     (void)test_dependency_1_out_arg(&actual_int);
@@ -1442,11 +1449,12 @@ TEST_FUNCTION(CopyOutArgumentBuffer_arg_name_when_an_error_occurs_preserves_the_
     // arrange
     int injected_int = 0x42;
     int injected_int_2 = 0x43;
+    int actual_int_1 = 0;
+    int actual_int_2 = 0;
     EXPECTED_CALL(test_dependency_2_out_args(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer_b(&injected_int, sizeof(injected_int))
         .CopyOutArgumentBuffer(0, &injected_int_2, sizeof(injected_int_2));
-    int actual_int_1 = 0;
-    int actual_int_2 = 0;
+
 
     // act
     (void)test_dependency_2_out_args(&actual_int_1, &actual_int_2);
@@ -1461,10 +1469,11 @@ TEST_FUNCTION(CopyOutArgumentBuffer_arg_name_overrides_the_buffer_for_CopyOutArg
     // arrange
     int injected_int = 0x42;
     int injected_int_2 = 0x43;
+    int actual_int = 0;
     EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer(1, &injected_int, sizeof(injected_int))
         .CopyOutArgumentBuffer_a(&injected_int_2, sizeof(injected_int_2));
-    int actual_int = 0;
+
 
     // act
     (void)test_dependency_1_out_arg(&actual_int);
@@ -1478,10 +1487,11 @@ TEST_FUNCTION(CopyOutArgumentBuffer_overrides_the_buffer_for_CopyOutArgumentBuff
     // arrange
     int injected_int = 0x42;
     int injected_int_2 = 0x43;
+    int actual_int = 0;
     EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer_a(&injected_int_2, sizeof(injected_int_2))
         .CopyOutArgumentBuffer(1, &injected_int, sizeof(injected_int));
-    int actual_int = 0;
+
 
     // act
     (void)test_dependency_1_out_arg(&actual_int);
@@ -1721,12 +1731,14 @@ TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_registers_a_hook_for_the_mock)
 TEST_FUNCTION(REGISTER_GLOBAL_MOCK_HOOK_registers_a_hook_for_the_mock_that_returns_2_different_values)
 {
     // arrange
+    int call1_result;
+    int call2_result;
     REGISTER_GLOBAL_MOCK_HOOK(test_dependency_no_args, my_hook_test_dependency_no_args);
     my_hook_result = 0x42;
 
     // act
-    int call1_result = test_dependency_no_args();
-    int call2_result = test_dependency_no_args();
+    call1_result = test_dependency_no_args();
+    call2_result = test_dependency_no_args();
 
     // assert
     ASSERT_ARE_EQUAL(int, 0x42, call1_result);
@@ -2137,11 +2149,12 @@ TEST_FUNCTION(an_expected_call_for_a_mock_function_with_code_ignores_args)
 TEST_FUNCTION(the_value_for_a_function_that_returns_a_char_ptr_is_freed)
 {
     // arrange
+    const char* result;
     EXPECTED_CALL(test_mock_function_returning_string())
         .SetReturn("a");
 
     // act
-    const char* result = test_mock_function_returning_string();
+    result = test_mock_function_returning_string();
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, "a", result);
@@ -2174,10 +2187,11 @@ TEST_FUNCTION(the_value_for_a_function_that_returns_a_char_ptr_with_a_default_is
 TEST_FUNCTION(the_value_for_a_function_that_returns_a_char_ptr_set_by_macro_is_freed)
 {
     // arrange
+    const char* result;
     REGISTER_GLOBAL_MOCK_RETURN(test_mock_function_returning_string_with_macro, "a");
 
     // act
-    const char* result = test_mock_function_returning_string_with_macro();
+    result = test_mock_function_returning_string_with_macro();
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, "a", result);
@@ -2189,12 +2203,13 @@ TEST_FUNCTION(the_value_for_a_function_that_returns_a_char_ptr_set_by_macro_is_f
 TEST_FUNCTION(registering_an_alias_type_works)
 {
     // arrange
+    funkytype result;
     REGISTER_UMOCK_ALIAS_TYPE(funkytype, int);
     STRICT_EXPECTED_CALL(test_mock_function_with_funkytype(42))
         .SetReturn(42);
 
     // act
-    funkytype result = test_mock_function_with_funkytype(42);
+    result = test_mock_function_with_funkytype(42);
 
     // assert
     ASSERT_ARE_EQUAL(int, 42, (int)result);
@@ -2206,12 +2221,13 @@ TEST_FUNCTION(registering_an_alias_type_works)
 TEST_FUNCTION(when_an_unregistered_pointer_type_is_used_it_defaults_to_void_ptr)
 {
     // arrange
+    unsigned char*** result;
     REGISTER_UMOCK_ALIAS_TYPE(funkytype, int);
     STRICT_EXPECTED_CALL(test_mock_function_with_unregistered_ptr_type((unsigned char***)0x42))
         .SetReturn((unsigned char***)0x42);
 
     // act
-    unsigned char*** result = test_mock_function_with_unregistered_ptr_type((unsigned char***)0x42);
+    result = test_mock_function_with_unregistered_ptr_type((unsigned char***)0x42);
 
     // assert
     ASSERT_ARE_EQUAL(void_ptr, (void*)0x42, result);
@@ -2471,10 +2487,11 @@ TEST_FUNCTION(validate_argument_value_shall_implicitly_validate_the_argument)
 TEST_FUNCTION(paired_calls_are_checked_and_no_leak_happens)
 {
     // arrange
+    SOME_HANDLE h;
     REGISTER_UMOCKC_PAIRED_CREATE_DESTROY_CALLS(some_create, some_destroy);
 
     // act
-    SOME_HANDLE h = some_create(42);
+    h = some_create(42);
     some_destroy(h);
 
     // assert
@@ -2525,10 +2542,11 @@ TEST_FUNCTION(when_registering_paired_calls_for_a_destroy_with_different_arg_typ
 TEST_FUNCTION(paired_calls_are_checked_with_a_struct_as_instance_type)
 {
     // arrange
+    SOME_STRUCT s;
     REGISTER_UMOCKC_PAIRED_CREATE_DESTROY_CALLS(some_create_with_struct, some_destroy_with_struct);
 
     // act
-    SOME_STRUCT s = some_create_with_struct(42);
+    s = some_create_with_struct(42);
     some_destroy_with_struct(s);
 
     // assert

--- a/tests/umock_c_int/umock_c_int.c
+++ b/tests/umock_c_int/umock_c_int.c
@@ -1382,9 +1382,9 @@ TEST_FUNCTION(CopyOutArgumentBuffer_arg_name_copies_the_memory_for_later_use)
 {
     // arrange
     int injected_int = 0x42;
+    int actual_int = 0;
     EXPECTED_CALL(test_dependency_1_out_arg(IGNORED_PTR_ARG))
         .CopyOutArgumentBuffer_a(&injected_int, sizeof(injected_int));
-    int actual_int = 0;
 
     injected_int = 0;
 
@@ -2742,6 +2742,8 @@ TEST_FUNCTION(auto_ignore_when_first_arg_is_a_nested_macro_succeeds_for_2nd_arg)
     ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_actual_calls());
 }
 
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1600
 /* Tests_SRS_UMOCK_C_LIB_01_205: [ If `IGNORED_PTR_ARG` or `IGNORED_NUM_ARG` is used as an argument value with `STRICT_EXPECTED_CALL`, the argument shall be automatically ignored. ]*/
 /* Tests_SRS_UMOCK_C_LIB_01_206: [ `IGNORED_PTR_ARG` shall be defined as NULL so that it can be used for pointer type arguments. ]*/
 TEST_FUNCTION(auto_ignore_when_first_arg_is_a_struct_succeeds_for_2nd_arg)
@@ -2772,6 +2774,7 @@ TEST_FUNCTION(auto_ignore_when_first_arg_is_a_struct_succeeds_for_2nd_arg)
     ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_expected_calls());
     ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_actual_calls());
 }
+#endif
 
 /* Tests_SRS_UMOCK_C_LIB_01_101: [The IgnoreAllCalls call modifier shall record that all calls matching the expected call shall be ignored. ]*/
 /* Tests_SRS_UMOCK_C_LIB_01_208: [ If no matching call occurs no missing call shall be reported. ]*/


### PR DESCRIPTION
The gate build for VS2008 is not enabling `-Drun_int_tests:bool=ON`.  When VS2008 tried to build the c-utility with umock submodule updated, it ended up finding problems in MOCKABLE_CALL that `-Drun_unittests:BOOL=on` by itself would not.

This PR:
* Fixes so that MOCKABLE_FUNCTION compiles under VS2008.
* Enables `-Drun_int_tests:bool=ON` cmake flag for VS2008 gated runs.
* Fixes problems in umock tests themselves discovered under `-Drun_int_tests:bool=ON` & VS2008.

Please pay particular attention to the test `auto_ignore_when_first_arg_is_a_struct_succeeds_for_2nd_arg`.  VS2008 doesn't like this construct of struct in function it seems.

To get past my gated buddy builds I've disabled test for lower versions of VS assuming it's flat out not supported, but not sure if that's legit or not?  From run with it enabled:
```
..\..\..\..\tests\umock_c_int\umock_c_int.c(2758): error C2059: syntax error : '{'
..\..\..\..\tests\umock_c_int\umock_c_int.c(2761): error C2059: syntax error : '{'
```

Obviously I'll take any feedback & squash prior to commit.  Thanks!