### PR TITLE
Move #include's to before the extern block defined for building with c++

### DIFF
--- a/inc/umock_c/umock_c.h
+++ b/inc/umock_c/umock_c.h
@@ -4,14 +4,15 @@
 #ifndef UMOCK_C_H
 #define UMOCK_C_H
 
+#include "azure_macro_utils/macro_utils.h"
+#include "umock_c/umockcallrecorder.h"
+
 #ifdef __cplusplus
 #include <cstdlib>
 extern "C" {
 #else
 #include <stdlib.h>
 #endif
-#include "azure_macro_utils/macro_utils.h"
-#include "umock_c/umockcallrecorder.h"
 
 /* Define UMOCK_STATIC to static to make mocks private to compilation unit */
 #ifndef UMOCK_STATIC

--- a/inc/umock_c/umock_c_internal.h
+++ b/inc/umock_c/umock_c_internal.h
@@ -4,15 +4,6 @@
 #ifndef UMOCK_C_INTERNAL_H
 #define UMOCK_C_INTERNAL_H
 
-#ifdef __cplusplus
-#include <cstdlib>
-extern "C" {
-#else
-#include <stdlib.h>
-#endif
-
-#include <stdio.h>
-
 #include "azure_macro_utils/macro_utils.h"
 #include "umock_c/umocktypes.h"
 #include "umock_c/umockcall.h"
@@ -23,6 +14,15 @@ extern "C" {
 #include "umock_c/umockcallpairs.h"
 #include "umock_c/umockstring.h"
 #include "umock_c/umockautoignoreargs.h"
+
+#ifdef __cplusplus
+#include <cstdlib>
+extern "C" {
+#else
+#include <stdlib.h>
+#endif
+
+#include <stdio.h>
 
 extern void umock_c_indicate_error(UMOCK_C_ERROR_CODE error_code);
 extern UMOCKCALL_HANDLE umock_c_get_last_expected_call(void);

--- a/inc/umock_c/umocktypes.h
+++ b/inc/umock_c/umocktypes.h
@@ -4,14 +4,14 @@
 #ifndef UMOCKTYPES_H
 #define UMOCKTYPES_H
 
+#include "umockalloc.h"
+
 #ifdef __cplusplus
 #include <cstddef>
 extern "C" {
 #else
 #include <stddef.h>
 #endif
-
-#include "umockalloc.h"
 
     typedef char*(*UMOCKTYPE_STRINGIFY_FUNC)(const void* value);
     typedef int(*UMOCKTYPE_COPY_FUNC)(void* destination, const void* source);


### PR DESCRIPTION
On clang we got build failures due to the fact that some of umock's headers were being included within the extern block.
A search for "Fix clang build failure, caused by mixing C and C++" gave the hint on how to fix this.
Also, for reference, current clang cstring.h seems to incorrectly redefine string.h functions (without 'const' on some of the arguments).