### PR TITLE
Use target_link_libraries for dependency to macro utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,10 @@ SOURCE_GROUP(devdoc FILES ${umock_c_md_files})
 
 add_library(umock_c ${umock_c_c_files} ${umock_c_h_files} ${umock_c_md_files})
 
+if(${use_installed_dependencies})
+    target_link_libraries(umock_c azure_macro_utils_c)
+endif()
+
 target_include_directories(umock_c
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/inc>


### PR DESCRIPTION
https://github.com/Azure/umock-c/issues/130