### PR TITLE
Improve auto ignore args to allow for macros expanding to a function name

### DIFF
--- a/devdoc/umockautoignoreargs_requirements.md
+++ b/devdoc/umockautoignoreargs_requirements.md
@@ -1,4 +1,4 @@
-﻿# umockautoignoreargs requirements
+﻿`umockautoignoreargs` requirements
 
 # Overview
 
@@ -16,20 +16,32 @@ int umockautoignoreargs_is_call_argument_ignored(const char* call, size_t argume
 int umockautoignoreargs_is_call_argument_ignored(const char* call, size_t argument_index, int* is_argument_ignored);
 ```
 
-XX**SRS_UMOCKAUTOIGNOREARGS_01_001: [** `umockautoignoreargs_is_call_argument_ignored` shall determine whether argument `argument_index` shall be ignored or not. **]**
+**SRS_UMOCKAUTOIGNOREARGS_01_001: [** `umockautoignoreargs_is_call_argument_ignored` shall determine whether argument `argument_index` shall be ignored or not. **]**
 
-XX**SRS_UMOCKAUTOIGNOREARGS_01_002: [** If `call` or `is_argument_ignored` is NULL, `umockautoignoreargs_is_call_argument_ignored` shall fail and return a non-zero value. **]**
+**SRS_UMOCKAUTOIGNOREARGS_01_002: [** If `call` or `is_argument_ignored` is NULL, `umockautoignoreargs_is_call_argument_ignored` shall fail and return a non-zero value. **]**
 
-XX**SRS_UMOCKAUTOIGNOREARGS_01_003: [** `umockautoignoreargs_is_call_argument_ignored` shall parse the `call` string as a function call: function_name(arg1, arg2, ...). **]**
+**SRS_UMOCKAUTOIGNOREARGS_01_003: [** `umockautoignoreargs_is_call_argument_ignored` shall parse the `call` string as a function call: function_name(arg1, arg2, ...). **]**
 
-XX**SRS_UMOCKAUTOIGNOREARGS_01_004: [** If `umockautoignoreargs_is_call_argument_ignored` fails parsing the `call` argument it shall fail and return a non-zero value. **]**
+**SRS_UMOCKAUTOIGNOREARGS_01_010: [** `umockautoignoreargs_is_call_argument_ignored` shall look for the arguments as being the string contained in the scope of the rightmost parenthesis set in `call`. **]**
 
-XX**SRS_UMOCKAUTOIGNOREARGS_01_009: [** If the number of arguments parsed from `call` is less than `argument_index`, `umockautoignoreargs_is_call_argument_ignored` shall fail and return a non-zero value. **]**
+Note: nesting is allowed. An example of arguments that would have nested parenthesis scope:
 
-XX**SRS_UMOCKAUTOIGNOREARGS_01_005: [** If `umockautoignoreargs_is_call_argument_ignored` was able to parse the `argument_index`th argument it shall succeed and return 0, while writing whether the argument is ignored in the `is_argument_ignored` output argument. **]**
+```c
+function_name(arg1, some_call(x), ...)
+```
 
-XX**SRS_UMOCKAUTOIGNOREARGS_01_006: [** If the argument value is `IGNORED_PTR_ARG` then `is_argument_ignored` shall be set to 1. **]**
+For this example, the arg list would be `arg1, some_call(x), ...`.
 
-XX**SRS_UMOCKAUTOIGNOREARGS_01_007: [** If the argument value is `IGNORED_NUM_ARG` then `is_argument_ignored` shall be set to 1. **]**
+**SRS_UMOCKAUTOIGNOREARGS_01_011: [** If a valid scope of the rightmost parenthesis set cannot be formed (imbalanced parenthesis for example), `umockautoignoreargs_is_call_argument_ignored` shall fail and return a non-zero value. **]**
 
-XX**SRS_UMOCKAUTOIGNOREARGS_01_008: [** If the argument value is any other value then `is_argument_ignored` shall be set to 0. **]**
+**SRS_UMOCKAUTOIGNOREARGS_01_004: [** If `umockautoignoreargs_is_call_argument_ignored` fails parsing the `call` argument it shall fail and return a non-zero value. **]**
+
+**SRS_UMOCKAUTOIGNOREARGS_01_009: [** If the number of arguments parsed from `call` is less than `argument_index`, `umockautoignoreargs_is_call_argument_ignored` shall fail and return a non-zero value. **]**
+
+**SRS_UMOCKAUTOIGNOREARGS_01_005: [** If `umockautoignoreargs_is_call_argument_ignored` was able to parse the `argument_index`th argument it shall succeed and return 0, while writing whether the argument is ignored in the `is_argument_ignored` output argument. **]**
+
+**SRS_UMOCKAUTOIGNOREARGS_01_006: [** If the argument value is `IGNORED_PTR_ARG` then `is_argument_ignored` shall be set to 1. **]**
+
+**SRS_UMOCKAUTOIGNOREARGS_01_007: [** If the argument value is `IGNORED_NUM_ARG` then `is_argument_ignored` shall be set to 1. **]**
+
+**SRS_UMOCKAUTOIGNOREARGS_01_008: [** If the argument value is any other value then `is_argument_ignored` shall be set to 0. **]**

--- a/src/umockautoignoreargs.c
+++ b/src/umockautoignoreargs.c
@@ -4,6 +4,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdbool.h>
+#include "azure_macro_utils/macro_utils.h"
 #include "umock_c/umockalloc.h"
 #include "umock_c/umockautoignoreargs.h"
 #include "umock_c/umock_log.h"
@@ -18,164 +20,219 @@ int umockautoignoreargs_is_call_argument_ignored(const char* call, size_t argume
 {
     int result;
 
-    if ((call == NULL) ||
-        (is_argument_ignored == NULL))
+    if (
+        (call == NULL) ||
+        (is_argument_ignored == NULL)
+        )
     {
         /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_002: [ If call or is_argument_ignored is NULL, umockautoignoreargs_is_call_argument_ignored shall fail and return a non-zero value. ]*/
-        result = __LINE__;
+        result = MU_FAILURE;
     }
     else
     {
-        const char* cur_pos = strchr(call, '(');
+        // find where the args start
+        size_t call_string_len = strlen(call);
+        size_t i = call_string_len;
+        size_t paren_scope_count = 0;
+        bool is_error = false;
 
-        if (cur_pos == NULL)
+        /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_010: [ umockautoignoreargs_is_call_argument_ignored shall look for the arguments as being the string contained in the scope of the rightmost parenthesis set in call. ]*/
+        do
         {
-            /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_004: [ If umockautoignoreargs_is_call_argument_ignored fails parsing the call argument it shall fail and return a non-zero value. ]*/
-            result = __LINE__;
+            i--;
+            
+            if (call[i] == ')')
+            {
+                paren_scope_count++;
+            }
+            else if (call[i] == '(')
+            {
+                if (paren_scope_count == 0)
+                {
+                    // error
+                    is_error = true;
+                    break;
+                }
+                else
+                {
+                    paren_scope_count--;
+                    if (paren_scope_count == 0)
+                    {
+                        // found the start of the args
+                        break;
+                    }
+                }
+            }
+        } while (i > 0);
+
+        if (
+            (is_error) ||
+            /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_011: [ If a valid scope of the rightmost parenthesis set cannot be formed (imbalanced parenthesis for example), `umockautoignoreargs_is_call_argument_ignored` shall fail and return a non-zero value. ]*/
+            (paren_scope_count > 0)
+            )
+        {
+            UMOCK_LOG("Invalid call string: %s", call);
+            result = MU_FAILURE;
         }
         else
         {
-            size_t argument_count = 1;
-            unsigned char argument_found = 0;
+            const char* cur_pos = &call[i];
 
-            /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_009: [ If the number of arguments parsed from call is less than argument_index, umockautoignoreargs_is_call_argument_ignored shall fail and return a non-zero value. ]*/
-            cur_pos++;
-
-            while (*cur_pos != '\0')
+            if (cur_pos == NULL)
             {
-                /* clear out all spaces */
-                while ((*cur_pos != '\0') && isspace(*cur_pos))
-                {
-                    cur_pos++;
-                }
+                /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_004: [ If umockautoignoreargs_is_call_argument_ignored fails parsing the call argument it shall fail and return a non-zero value. ]*/
+                result = MU_FAILURE;
+            }
+            else
+            {
+                size_t argument_count = 1;
+                unsigned char argument_found = 0;
 
-                if (*cur_pos != '\0')
+                /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_009: [ If the number of arguments parsed from call is less than argument_index, umockautoignoreargs_is_call_argument_ignored shall fail and return a non-zero value. ]*/
+                cur_pos++;
+
+                while (*cur_pos != '\0')
                 {
-                    if (*cur_pos == ')')
+                    /* clear out all spaces */
+                    while ((*cur_pos != '\0') && isspace(*cur_pos))
                     {
-                        /* no more args and we did not get to the arg we wanted */
-                        /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_009: [ If the number of arguments parsed from call is less than argument_index, umockautoignoreargs_is_call_argument_ignored shall fail and return a non-zero value. ]*/
-                        result = __LINE__;
-                        break;
+                        cur_pos++;
                     }
-                    else
-                    {
-                        if (argument_count == argument_index)
-                        {
-                            /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_006: [ If the argument value is IGNORED_PTR_ARG then is_argument_ignored shall be set to 1. ]*/
-                            if ((strncmp(cur_pos, ignore_ptr_arg_string, sizeof(ignore_ptr_arg_string) - 1) == 0) ||
-                                /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_007: [ If the argument value is IGNORED_NUM_ARG then is_argument_ignored shall be set to 1. ]*/
-                                (strncmp(cur_pos, ignore_num_arg_string, sizeof(ignore_num_arg_string) - 1) == 0))
-                            {
-                                /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_005: [ If umockautoignoreargs_is_call_argument_ignored was able to parse the argument_indexth argument it shall succeed and return 0, while writing whether the argument is ignored in the is_argument_ignored output argument. ]*/
-                                *is_argument_ignored = 1;
-                            }
-                            else
-                            {
-                                /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_008: [ If the argument value is any other value then is_argument_ignored shall be set to 0. ]*/
-                                /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_005: [ If umockautoignoreargs_is_call_argument_ignored was able to parse the argument_indexth argument it shall succeed and return 0, while writing whether the argument is ignored in the is_argument_ignored output argument. ]*/
-                                *is_argument_ignored = 0;
-                            }
 
-                            argument_found = 1;
+                    if (*cur_pos != '\0')
+                    {
+                        if (*cur_pos == ')')
+                        {
+                            /* no more args and we did not get to the arg we wanted */
+                            /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_009: [ If the number of arguments parsed from call is less than argument_index, umockautoignoreargs_is_call_argument_ignored shall fail and return a non-zero value. ]*/
+                            result = MU_FAILURE;
                             break;
                         }
                         else
                         {
-                            unsigned char parser_stack[PARSER_STACK_DEPTH];
-                            size_t parser_stack_index = 0;
-                            int parse_error = 0;
-
-                            /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_003: [ umockautoignoreargs_is_call_argument_ignored shall parse the call string as a function call: function_name(arg1, arg2, ...). ]*/
-                            while ((*cur_pos != '\0') && 
-                                ((*cur_pos != ',') || (parser_stack_index > 0)))
+                            if (argument_count == argument_index)
                             {
-                                if (*cur_pos == '(')
+                                if (
+                                    /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_006: [ If the argument value is IGNORED_PTR_ARG then is_argument_ignored shall be set to 1. ]*/
+                                    (strncmp(cur_pos, ignore_ptr_arg_string, sizeof(ignore_ptr_arg_string) - 1) == 0) ||
+                                    /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_007: [ If the argument value is IGNORED_NUM_ARG then is_argument_ignored shall be set to 1. ]*/
+                                    (strncmp(cur_pos, ignore_num_arg_string, sizeof(ignore_num_arg_string) - 1) == 0)
+                                    )
                                 {
-                                    if (parser_stack_index == PARSER_STACK_DEPTH)
-                                    {
-                                        /* error*/
-                                        parse_error = 1;
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        parser_stack[parser_stack_index] = 1;
-                                        parser_stack_index++;
-                                    }
+                                    /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_005: [ If umockautoignoreargs_is_call_argument_ignored was able to parse the argument_indexth argument it shall succeed and return 0, while writing whether the argument is ignored in the is_argument_ignored output argument. ]*/
+                                    *is_argument_ignored = 1;
                                 }
-                                if (*cur_pos == ')')
+                                else
                                 {
-                                    if (parser_stack_index == 0)
-                                    {
-                                        /* error*/
-                                        parse_error = 1;
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        if (parser_stack[parser_stack_index - 1] == 1)
-                                        {
-                                            parser_stack_index--;
-                                        }
-                                    }
-                                }
-                                if (*cur_pos == '{')
-                                {
-                                    if (parser_stack_index == PARSER_STACK_DEPTH)
-                                    {
-                                        /* error*/
-                                        parse_error = 1;
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        parser_stack[parser_stack_index] = 2;
-                                        parser_stack_index++;
-                                    }
-                                }
-                                if (*cur_pos == '}')
-                                {
-                                    if (parser_stack_index == 0)
-                                    {
-                                        /* error*/
-                                        parse_error = 1;
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        if (parser_stack[parser_stack_index - 1] == 2)
-                                        {
-                                            parser_stack_index--;
-                                        }
-                                    }
+                                    /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_008: [ If the argument value is any other value then is_argument_ignored shall be set to 0. ]*/
+                                    /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_005: [ If umockautoignoreargs_is_call_argument_ignored was able to parse the argument_indexth argument it shall succeed and return 0, while writing whether the argument is ignored in the is_argument_ignored output argument. ]*/
+                                    *is_argument_ignored = 0;
                                 }
 
-                                cur_pos++;
-                            }
-
-                            if ((*cur_pos == '\0') ||
-                                parse_error)
-                            {
+                                argument_found = 1;
                                 break;
                             }
                             else
                             {
-                                argument_count++;
-                                cur_pos++;
+                                unsigned char parser_stack[PARSER_STACK_DEPTH];
+                                size_t parser_stack_index = 0;
+                                int parse_error = 0;
+
+                                /* Codes_SRS_UMOCKAUTOIGNOREARGS_01_003: [ umockautoignoreargs_is_call_argument_ignored shall parse the call string as a function call: function_name(arg1, arg2, ...). ]*/
+                                while (
+                                    (*cur_pos != '\0') &&
+                                    ((*cur_pos != ',') || (parser_stack_index > 0))
+                                    )
+                                {
+                                    if (*cur_pos == '(')
+                                    {
+                                        if (parser_stack_index == PARSER_STACK_DEPTH)
+                                        {
+                                            /* error*/
+                                            parse_error = 1;
+                                            break;
+                                        }
+                                        else
+                                        {
+                                            parser_stack[parser_stack_index] = 1;
+                                            parser_stack_index++;
+                                        }
+                                    }
+                                    if (*cur_pos == ')')
+                                    {
+                                        if (parser_stack_index == 0)
+                                        {
+                                            /* error*/
+                                            parse_error = 1;
+                                            break;
+                                        }
+                                        else
+                                        {
+                                            if (parser_stack[parser_stack_index - 1] == 1)
+                                            {
+                                                parser_stack_index--;
+                                            }
+                                        }
+                                    }
+                                    if (*cur_pos == '{')
+                                    {
+                                        if (parser_stack_index == PARSER_STACK_DEPTH)
+                                        {
+                                            /* error*/
+                                            parse_error = 1;
+                                            break;
+                                        }
+                                        else
+                                        {
+                                            parser_stack[parser_stack_index] = 2;
+                                            parser_stack_index++;
+                                        }
+                                    }
+                                    if (*cur_pos == '}')
+                                    {
+                                        if (parser_stack_index == 0)
+                                        {
+                                            /* error*/
+                                            parse_error = 1;
+                                            break;
+                                        }
+                                        else
+                                        {
+                                            if (parser_stack[parser_stack_index - 1] == 2)
+                                            {
+                                                parser_stack_index--;
+                                            }
+                                        }
+                                    }
+
+                                    cur_pos++;
+                                }
+
+                                if (
+                                    (*cur_pos == '\0') ||
+                                    parse_error
+                                    )
+                                {
+                                    break;
+                                }
+                                else
+                                {
+                                    argument_count++;
+                                    cur_pos++;
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            if (argument_found)
-            {
-                result = 0;
-            }
-            else
-            {
-                result = __LINE__;
+                if (argument_found)
+                {
+                    result = 0;
+                }
+                else
+                {
+                    result = MU_FAILURE;
+                }
             }
         }
     }

--- a/tests/umock_c_int/umock_c_int.c
+++ b/tests/umock_c_int/umock_c_int.c
@@ -3108,4 +3108,38 @@ TEST_FUNCTION(SetReturn_overrides_MOCKABLE_FUNCTION_WITH_RETURNS)
     ASSERT_ARE_EQUAL(int, 44, result);
 }
 
+#define WRAPPER_MACRO(a) a
+
+/* Tests_SRS_UMOCK_C_LIB_01_205: [ If `IGNORED_PTR_ARG` or `IGNORED_NUM_ARG` is used as an argument value with `STRICT_EXPECTED_CALL`, the argument shall be automatically ignored. ]*/
+TEST_FUNCTION(IGNORED_PTR_ARG_works_with_another_macro_wrapping_function_name)
+{
+    // arrange
+    unsigned char x[1] = { 42 };
+
+    STRICT_EXPECTED_CALL(WRAPPER_MACRO(test_dependency_buffer_arg)(IGNORED_PTR_ARG));
+
+    // act
+    WRAPPER_MACRO(test_dependency_buffer_arg)(x);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_expected_calls());
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_UMOCK_C_LIB_01_205: [ If `IGNORED_PTR_ARG` or `IGNORED_NUM_ARG` is used as an argument value with `STRICT_EXPECTED_CALL`, the argument shall be automatically ignored. ]*/
+TEST_FUNCTION(IGNORED_NUM_ARG_works_with_another_macro_wrapping_function_name)
+{
+    // arrange
+    int x = 42;
+
+    STRICT_EXPECTED_CALL(WRAPPER_MACRO(test_dependency_1_arg_no_return)(IGNORED_NUM_ARG));
+
+    // act
+    WRAPPER_MACRO(test_dependency_1_arg_no_return)(x);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_expected_calls());
+    ASSERT_ARE_EQUAL(char_ptr, "", umock_c_get_actual_calls());
+}
+
 END_TEST_SUITE(umock_c_integrationtests)

--- a/tests/umockautoignoreargs_ut/umockautoignoreargs_ut.c
+++ b/tests/umockautoignoreargs_ut/umockautoignoreargs_ut.c
@@ -322,4 +322,120 @@ TEST_FUNCTION(umockautoignoreargs_is_call_argument_ignored_for_2nd_arg_when_firs
     ASSERT_ARE_EQUAL(int, 1, is_ignored);
 }
 
+/* Tests_SRS_UMOCKAUTOIGNOREARGS_01_010: [ umockautoignoreargs_is_call_argument_ignored shall look for the arguments as being the string contained in the scope of the rightmost parenthesis set in call. ]*/
+TEST_FUNCTION(umockautoignoreargs_is_call_argument_ignored_for_ignored_ptr_arg_when_other_parens_are_present_in_function_call)
+{
+    // arrange
+    int result;
+    int is_ignored;
+
+    // act
+    result = umockautoignoreargs_is_call_argument_ignored("WRAPPER(a)(IGNORED_PTR_ARG)", 1, &is_ignored);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 1, is_ignored);
+}
+
+/* Tests_SRS_UMOCKAUTOIGNOREARGS_01_010: [ umockautoignoreargs_is_call_argument_ignored shall look for the arguments as being the string contained in the scope of the rightmost parenthesis set in call. ]*/
+TEST_FUNCTION(umockautoignoreargs_is_call_argument_ignored_for_ignored_num_arg_when_other_parens_are_present_in_function_call)
+{
+    // arrange
+    int result;
+    int is_ignored;
+
+    // act
+    result = umockautoignoreargs_is_call_argument_ignored("WRAPPER(a)(IGNORED_NUM_ARG)", 1, &is_ignored);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 1, is_ignored);
+}
+
+/* Tests_SRS_UMOCKAUTOIGNOREARGS_01_010: [ umockautoignoreargs_is_call_argument_ignored shall look for the arguments as being the string contained in the scope of the rightmost parenthesis set in call. ]*/
+TEST_FUNCTION(umockautoignoreargs_is_call_argument_ignored_when_RPAREN_missing_at_end_fails)
+{
+    // arrange
+    int result;
+    int is_ignored;
+
+    // act
+    result = umockautoignoreargs_is_call_argument_ignored("WRAPPER(a)(IGNORED_NUM_ARG(", 1, &is_ignored);
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+}
+
+/* Tests_SRS_UMOCKAUTOIGNOREARGS_01_010: [ umockautoignoreargs_is_call_argument_ignored shall look for the arguments as being the string contained in the scope of the rightmost parenthesis set in call. ]*/
+TEST_FUNCTION(umockautoignoreargs_is_call_argument_ignored_when_extra_LPAREN_at_end_fails)
+{
+    // arrange
+    int result;
+    int is_ignored;
+
+    // act
+    result = umockautoignoreargs_is_call_argument_ignored("WRAPPER(a)(IGNORED_NUM_ARG)(", 1, &is_ignored);
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+}
+
+/* Tests_SRS_UMOCKAUTOIGNOREARGS_01_010: [ umockautoignoreargs_is_call_argument_ignored shall look for the arguments as being the string contained in the scope of the rightmost parenthesis set in call. ]*/
+TEST_FUNCTION(umockautoignoreargs_is_call_argument_ignored_when_extra_LPAREN_RPAREN_at_end_fails)
+{
+    // arrange
+    int result;
+    int is_ignored;
+
+    // act
+    result = umockautoignoreargs_is_call_argument_ignored("WRAPPER(a)(IGNORED_NUM_ARG)()", 1, &is_ignored);
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+}
+
+/* Tests_SRS_UMOCKAUTOIGNOREARGS_01_010: [ umockautoignoreargs_is_call_argument_ignored shall look for the arguments as being the string contained in the scope of the rightmost parenthesis set in call. ]*/
+TEST_FUNCTION(umockautoignoreargs_is_call_argument_ignored_when_another_call_is_in_args_succeeds)
+{
+    // arrange
+    int result;
+    int is_ignored;
+
+    // act
+    result = umockautoignoreargs_is_call_argument_ignored("WRAPPER(a)(IGNORED_NUM_ARG, b(0))", 1, &is_ignored);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 1, is_ignored);
+}
+
+/* Tests_SRS_UMOCKAUTOIGNOREARGS_01_010: [ umockautoignoreargs_is_call_argument_ignored shall look for the arguments as being the string contained in the scope of the rightmost parenthesis set in call. ]*/
+TEST_FUNCTION(umockautoignoreargs_is_call_argument_ignored_when_another_value_is_enclosed_with_parens_succeeds)
+{
+    // arrange
+    int result;
+    int is_ignored;
+
+    // act
+    result = umockautoignoreargs_is_call_argument_ignored("WRAPPER(a)(IGNORED_NUM_ARG, (0))", 1, &is_ignored);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(int, 1, is_ignored);
+}
+
+/* Tests_SRS_UMOCKAUTOIGNOREARGS_01_011: [ If a valid scope of the rightmost parenthesis set cannot be formed (imbalanced parenthesis for example), `umockautoignoreargs_is_call_argument_ignored` shall fail and return a non-zero value. ]*/
+TEST_FUNCTION(umockautoignoreargs_is_call_argument_ignored_with_not_enough_LPARENs_for_args_fails)
+{
+    // arrange
+    int result;
+    int is_ignored;
+
+    // act
+    result = umockautoignoreargs_is_call_argument_ignored("IGNORED_NUM_ARG, (0))", 1, &is_ignored);
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+}
+
 END_TEST_SUITE(umockautoignoreargs_unittests)


### PR DESCRIPTION
Improve auto ignore args to allow for macros expanding to a function name