### PR TITLE
Add a function to negative_tests to get a call description (using stringify)

### DIFF
--- a/devdoc/umock_c_negative_tests_requirements.md
+++ b/devdoc/umock_c_negative_tests_requirements.md
@@ -117,5 +117,16 @@ XX**SRS_UMOCK_C_NEGATIVE_TESTS_01_021: [** `umock_c_negative_tests_call_count` s
 
 **SRS_UMOCK_C_NEGATIVE_TESTS_31_029: [** If `umockcallrecorder_can_call_fail` fails, `umock_c_negative_tests_fail_call` shall indicate the error via the umock error callback with error code `UMOCK_C_ERROR` and return 1.  **]**
 
+## umock_c_negative_tests_get_call_description
 
+```c
+    char* umock_c_negative_tests_get_call_description(size_t index);
+```
 
+**SRS_UMOCK_C_NEGATIVE_TESTS_09_001: [** If the module was not previously initialized, `umock_c_negative_tests_get_call_description` shall indicate the error via the umock error callback with error code `UMOCK_C_ERROR`.  **]**
+
+**SRS_UMOCK_C_NEGATIVE_TESTS_09_002: [** If `umock_c_get_call_recorder` fails, `umock_c_negative_tests_get_call_description` shall indicate the error via the umock error callback with error code `UMOCK_C_ERROR`.  **]**
+
+**SRS_UMOCK_C_NEGATIVE_TESTS_09_003: [** If any failure occurs `umock_c_negative_tests_get_call_description` shall return NULL.  **]**
+
+**SRS_UMOCK_C_NEGATIVE_TESTS_09_004: [** Otherwise `umock_c_negative_tests_get_call_description` shall return the result of `umockcallrecorder_get_expected_call_string`.  **]**

--- a/devdoc/umockcallrecorder_requirements.md
+++ b/devdoc/umockcallrecorder_requirements.md
@@ -22,6 +22,7 @@
     int umockcallrecorder_get_expected_call_count(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t* expected_call_count);
     int umockcallrecorder_fail_call(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index);
     int umockcallrecorder_can_call_fail(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index, int* can_call_fail);
+    char* umockcallrecorder_get_expected_call_string(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index);
 ```
 
 ### umockcallrecorder_create
@@ -297,3 +298,12 @@ int umockcallrecorder_can_call_fail(UMOCKCALLRECORDER_HANDLE umock_call_recorder
 **SRS_UMOCKCALLRECORDER_01_094: [** If a lock was created for the call recorder, `umockcallrecorder_can_call_fail` shall release the exclusive lock. **]**
 
 **SRS_UMOCKCALLRECORDER_31_060: [** On success `umockcallrecorder_can_call_fail` shall return 0. **]**
+
+### umockcallrecorder_get_expected_call_string
+
+```c
+char* umockcallrecorder_get_expected_call_string(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index);
+```
+**SRS_UMOCKCALLRECORDER_09_001: [** If `umock_call_recorder` or `index` is >= `expected_call_count`, `umockcallrecorder_can_call_fail` shall return NULL. **]**
+
+**SRS_UMOCKCALLRECORDER_09_002: [** Otherwise `umockcallrecorder_can_call_fail` shall call `umockcall_stringify` over `expected_calls[index].umockcall` and return the resulting string. **]**

--- a/inc/umock_c/umock_c_negative_tests.h
+++ b/inc/umock_c/umock_c_negative_tests.h
@@ -21,6 +21,7 @@ extern "C" {
     void umock_c_negative_tests_fail_call(size_t index);
     size_t umock_c_negative_tests_call_count(void);
     int umock_c_negative_tests_can_call_fail(size_t index);
+    char* umock_c_negative_tests_get_call_description(size_t index);
 
 #ifdef __cplusplus
 }

--- a/inc/umock_c/umockcallrecorder.h
+++ b/inc/umock_c/umockcallrecorder.h
@@ -31,7 +31,7 @@ extern "C" {
     int umockcallrecorder_get_expected_call_count(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t* expected_call_count);
     int umockcallrecorder_fail_call(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index);
     int umockcallrecorder_can_call_fail(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index, int* can_call_fail);
-    char* umockcallrecorder_get_call_description(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index);
+    char* umockcallrecorder_get_expected_call_string(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index);
 
 #ifdef __cplusplus
 }

--- a/inc/umock_c/umockcallrecorder.h
+++ b/inc/umock_c/umockcallrecorder.h
@@ -31,6 +31,7 @@ extern "C" {
     int umockcallrecorder_get_expected_call_count(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t* expected_call_count);
     int umockcallrecorder_fail_call(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index);
     int umockcallrecorder_can_call_fail(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index, int* can_call_fail);
+    char* umockcallrecorder_get_call_description(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index);
 
 #ifdef __cplusplus
 }

--- a/src/umock_c_negative_tests.c
+++ b/src/umock_c_negative_tests.c
@@ -234,4 +234,30 @@ int umock_c_negative_tests_can_call_fail(size_t index)
     return can_call_fail;
 }
 
+char* umock_c_negative_tests_get_call_description(size_t index)
+{
+    char* result = NULL;
 
+    if (umock_c_negative_tests_state != UMOCK_C_NEGATIVE_TESTS_STATE_INITIALIZED)
+    {
+        /* Codes_SRS_UMOCK_C_NEGATIVE_TESTS_31_026: [ If the module was not previously initialized, umock_c_negative_tests_can_call_fail shall return 1. ]*/
+        UMOCK_LOG("umock_c_negative_tests_fail_call: Not initialized.");
+        umock_c_indicate_error(UMOCK_C_ERROR);
+    }
+    else
+    {
+        UMOCKCALLRECORDER_HANDLE call_recorder = umock_c_get_call_recorder();
+        if (call_recorder == NULL)
+        {
+            /* Codes_SRS_UMOCK_C_NEGATIVE_TESTS_31_027: [ If umock_c_get_call_recorder fails, umock_c_negative_tests_can_call_fail shall indicate the error via the umock error callback with error code UMOCK_C_ERROR. ]*/
+            UMOCK_LOG("umock_c_negative_tests_fail_call: Cannot get call recorder.");
+            umock_c_indicate_error(UMOCK_C_ERROR);
+        }
+        else
+        {
+            result = umockcallrecorder_get_call_description(call_recorder, index);
+        }
+    }
+
+    return result;
+}

--- a/src/umock_c_negative_tests.c
+++ b/src/umock_c_negative_tests.c
@@ -236,26 +236,29 @@ int umock_c_negative_tests_can_call_fail(size_t index)
 
 char* umock_c_negative_tests_get_call_description(size_t index)
 {
+    /* Codes_SRS_UMOCK_C_NEGATIVE_TESTS_09_003: [ If any failure occurs `umock_c_negative_tests_get_call_description` shall return NULL. ]*/
     char* result = NULL;
 
+    /* Codes_SRS_UMOCK_C_NEGATIVE_TESTS_09_001: [ If the module was not previously initialized, `umock_c_negative_tests_get_call_description` shall indicate the error via the umock error callback with error code `UMOCK_C_ERROR`. ]*/
     if (umock_c_negative_tests_state != UMOCK_C_NEGATIVE_TESTS_STATE_INITIALIZED)
     {
-        /* Codes_SRS_UMOCK_C_NEGATIVE_TESTS_31_026: [ If the module was not previously initialized, umock_c_negative_tests_can_call_fail shall return 1. ]*/
+
         UMOCK_LOG("umock_c_negative_tests_fail_call: Not initialized.");
         umock_c_indicate_error(UMOCK_C_ERROR);
     }
     else
     {
+        /* Codes_SRS_UMOCK_C_NEGATIVE_TESTS_09_002: [ If `umock_c_get_call_recorder` fails, `umock_c_negative_tests_get_call_description` shall indicate the error via the umock error callback with error code `UMOCK_C_ERROR`. ]*/
         UMOCKCALLRECORDER_HANDLE call_recorder = umock_c_get_call_recorder();
         if (call_recorder == NULL)
         {
-            /* Codes_SRS_UMOCK_C_NEGATIVE_TESTS_31_027: [ If umock_c_get_call_recorder fails, umock_c_negative_tests_can_call_fail shall indicate the error via the umock error callback with error code UMOCK_C_ERROR. ]*/
             UMOCK_LOG("umock_c_negative_tests_fail_call: Cannot get call recorder.");
             umock_c_indicate_error(UMOCK_C_ERROR);
         }
         else
         {
-            result = umockcallrecorder_get_call_description(call_recorder, index);
+            /* Codes_SRS_UMOCK_C_NEGATIVE_TESTS_09_004: [ Otherwise `umock_c_negative_tests_get_call_description` shall return the result of `umockcallrecorder_get_expected_call_string`. ]*/
+            result = umockcallrecorder_get_expected_call_string(call_recorder, index);
         }
     }
 

--- a/src/umockcallrecorder.c
+++ b/src/umockcallrecorder.c
@@ -830,20 +830,20 @@ int umockcallrecorder_can_call_fail(UMOCKCALLRECORDER_HANDLE umock_call_recorder
     return result;
 }
 
-char* umockcallrecorder_get_call_description(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index)
+char* umockcallrecorder_get_expected_call_string(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index)
 {
     char* result = NULL;
 
-    /* Codes_SRS_UMOCKCALLRECORDER_31_056: [ If umock_call_recorder or call_can_fail is NULL, umockcallrecorder_can_call_fail shall return a non-zero value. ]*/
+    /* Codes_SRS_UMOCKCALLRECORDER_09_001: [ If `umock_call_recorder` or `index` is >= `expected_call_count`, `umockcallrecorder_can_call_fail` shall return NULL. ]*/
     if ((umock_call_recorder == NULL) ||
-        /* Codes_SRS_UMOCKCALLRECORDER_31_057: [ If index is greater or equal to the current expected calls count, umockcallrecorder_can_call_fail shall return a non-zero value. ]*/
         (index >= umock_call_recorder->expected_call_count))
     {
-        UMOCK_LOG("umockcallrecorder_can_call_fail: NULL Invalid arguments, umock_call_recorder = %p, index = %zu",
+        UMOCK_LOG("umockcallrecorder_get_expected_call_string: NULL Invalid arguments, umock_call_recorder = %p, index = %zu",
             umock_call_recorder, index);
     }
     else
     {
+        /* Codes_SRS_UMOCKCALLRECORDER_09_002: [ Otherwise `umockcallrecorder_can_call_fail` shall call `umockcall_stringify` over `expected_calls[index].umockcall` and return the resulting string. ]*/
         result = umockcall_stringify(umock_call_recorder->expected_calls[index].umockcall);
     }
 

--- a/src/umockcallrecorder.c
+++ b/src/umockcallrecorder.c
@@ -829,3 +829,23 @@ int umockcallrecorder_can_call_fail(UMOCKCALLRECORDER_HANDLE umock_call_recorder
 
     return result;
 }
+
+char* umockcallrecorder_get_call_description(UMOCKCALLRECORDER_HANDLE umock_call_recorder, size_t index)
+{
+    char* result = NULL;
+
+    /* Codes_SRS_UMOCKCALLRECORDER_31_056: [ If umock_call_recorder or call_can_fail is NULL, umockcallrecorder_can_call_fail shall return a non-zero value. ]*/
+    if ((umock_call_recorder == NULL) ||
+        /* Codes_SRS_UMOCKCALLRECORDER_31_057: [ If index is greater or equal to the current expected calls count, umockcallrecorder_can_call_fail shall return a non-zero value. ]*/
+        (index >= umock_call_recorder->expected_call_count))
+    {
+        UMOCK_LOG("umockcallrecorder_can_call_fail: NULL Invalid arguments, umock_call_recorder = %p, index = %zu",
+            umock_call_recorder, index);
+    }
+    else
+    {
+        result = umockcall_stringify(umock_call_recorder->expected_calls[index].umockcall);
+    }
+
+    return result;
+}

--- a/tests/umockcallrecorder_ut/umockcallrecorder_ut.c
+++ b/tests/umockcallrecorder_ut/umockcallrecorder_ut.c
@@ -2793,4 +2793,61 @@ TEST_FUNCTION(umockcallrecorder_can_call_fail_with_lock_functions_setup_locks_an
     umockcallrecorder_destroy(call_recorder);
 }
 
+
+/* Tests_SRS_UMOCKCALLRECORDER_09_002: [ Otherwise `umockcallrecorder_can_call_fail` shall call `umockcall_stringify` over `expected_calls[index].umockcall` and return the resulting string. ]*/
+TEST_FUNCTION(umockcallrecorder_get_expected_call_string_succeeds)
+{
+    // arrange
+    char* result;
+    UMOCKCALLRECORDER_HANDLE call_recorder = umockcallrecorder_create(NULL, NULL);
+    (void)umockcallrecorder_add_expected_call(call_recorder, test_expected_umockcall_1);
+
+    reset_all_calls();
+    // act
+    result = umockcallrecorder_get_expected_call_string(call_recorder, 0);
+
+    // assert
+    ASSERT_ARE_EQUAL(size_t, 1, mocked_call_count);
+    ASSERT_ARE_EQUAL(void_ptr, test_expected_umockcall_1, mocked_calls[0].u.umockcall_get_fail_call.umockcall);
+    ASSERT_ARE_EQUAL(char_ptr, umockcall_stringify_call_result, result);
+
+    // cleanup
+    umockcallrecorder_destroy(call_recorder);
+}
+
+/* Tests_SRS_UMOCKCALLRECORDER_09_001: [ If `umock_call_recorder` or `index` is >= `expected_call_count`, `umockcallrecorder_can_call_fail` shall return NULL. ]*/
+TEST_FUNCTION(umockcallrecorder_get_expected_call_string_NULL_handle_fails)
+{
+    // arrange
+    char* result;
+
+    reset_all_calls();
+    // act
+    result = umockcallrecorder_get_expected_call_string(NULL, 0);
+
+    // assert
+    ASSERT_IS_NULL(result);
+
+    // cleanup
+}
+
+/* Tests_SRS_UMOCKCALLRECORDER_09_001: [ If `umock_call_recorder` or `index` is >= `expected_call_count`, `umockcallrecorder_can_call_fail` shall return NULL. ]*/
+TEST_FUNCTION(umockcallrecorder_get_expected_call_string_index_out_of_bounds_fails)
+{
+    // arrange
+    char* result;
+    UMOCKCALLRECORDER_HANDLE call_recorder = umockcallrecorder_create(NULL, NULL);
+    (void)umockcallrecorder_add_expected_call(call_recorder, test_expected_umockcall_1);
+
+    reset_all_calls();
+    // act
+    result = umockcallrecorder_get_expected_call_string(call_recorder, 1);
+
+    // assert
+    ASSERT_IS_NULL(result);
+
+    // cleanup
+    umockcallrecorder_destroy(call_recorder);
+}
+
 END_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)


### PR DESCRIPTION
This will help identifying the offending STRICT_EXPECTED_CALL when defining negative tests.

Example:

```c
...
        umock_c_negative_tests_snapshot();
        size_t call_count = umock_c_negative_tests_call_count();

        //act
        for (size_t i = 0; i < call_count; i++)
        {
            if (umock_c_negative_tests_can_call_fail(i))
            {
                // arrange
                char error_msg[128];
                char* call_description = umock_c_negative_tests_get_call_description(i);
                (void)sprintf(error_msg, "Failure in test %zu/%zu (%s)", i, call_count, call_description);
                my_gballoc_free(call_description);

                umock_c_negative_tests_reset();
                umock_c_negative_tests_fail_call(i);

                int result = call_my_public_function();

                //assert
                ASSERT_ARE_NOT_EQUAL(int, 0, result, error_msg);
            }
        }
```